### PR TITLE
🔄deps: Update Golang version from 1.22 to 1.23 in Dockerfile

### DIFF
--- a/back/Dockerfile
+++ b/back/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download


### PR DESCRIPTION
- update the golang base image version in `Dockerfile` from 1.22 to 1.23
- ensure compatibility with latest Golang runtime environment