### PR TITLE
👷chore: upgrade Go version from `1.23.0` to `1.24.1`

### DIFF
--- a/back/go.mod
+++ b/back/go.mod
@@ -1,6 +1,6 @@
 module github.com/yanosea/yanoPortfolioBack
 
-go 1.23.0
+go 1.24.1
 
 require (
 	github.com/labstack/echo/v4 v4.13.3


### PR DESCRIPTION
- update Go version in `go.mod` file to use the latest stable release
- this upgrade ensures compatibility with newer language features and security fixes provided in Go `1.24.1`