### PR TITLE
👷chore: add dependency groups to `Dependabot` configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,15 @@ updates:
     directory: "/back"
     schedule:
       interval: "weekly"
-
+    groups:
+      dependencies:
+        patterns:
+          - '*'
   - package-ecosystem: "npm"
     directory: "/front"
     schedule:
       interval: "weekly"
+    groups:
+      dependencies:
+        patterns:
+          - '*'


### PR DESCRIPTION
- configure `Dependabot` to group all dependency updates together
- apply grouping for `Go` modules in `/back` directory
- apply grouping for `npm` packages in `/front` directory
- improve dependency management by reducing number of PRs