### PR TITLE
🐞fix(workflow): re-add push trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,6 +2,8 @@
 # This workflow file is configured to analyze JavaScript/TypeScript (frontend and Deno backend)
 name: "CodeQL"
 on:
+  push:
+    branches: ["main"]
   pull_request:
     branches: ["main"]
   schedule:


### PR DESCRIPTION
- add `push` trigger for `main` branch to resolve warning
- enable code scanning alerts on security tab for default branch
- fix "MissingPushHook" validation error in CodeQL workflow
- reverts part of 6cafcde which removed push trigger