### PR TITLE
🐞fix(front): prevent dark mode flash on initial page load

### DIFF
--- a/front/src/layouts/BaseLayout.astro
+++ b/front/src/layouts/BaseLayout.astro
@@ -96,7 +96,7 @@ const url = new URL(Astro.props.url || "", "https://yanosea.org/").toString();
           if (localStorageTheme === classNameDark) {
             setClassOnDocumentBody();
           }
-        } else if (supportsColorSchemeQuery) {
+        } else if (supportsColorSchemeQuery && mql.matches) {
           setClassOnDocumentBody();
           localStorage.setItem(storageKey, classNameDark);
         }


### PR DESCRIPTION
- add `mql.matches` check to verify system actually prefers dark mode
- fix FOUC issue where light mode briefly appears before dark mode
- ensure theme is only applied when system preference matches