### PR TITLE
🔧refactor(cache): simplify cache service to generic get/set

### DIFF
--- a/back/src/domain/spotify/cache_constants.ts
+++ b/back/src/domain/spotify/cache_constants.ts
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Cache constants
+ */
+
+/**
+ * Cache keys for Spotify-related data
+ * These match the actual keys used in SpotifyApiClient and OAuthService
+ * @constant {object} SPOTIFY_CACHE_KEYS - Cache keys
+ */
+export const SPOTIFY_CACHE_KEYS = {
+  NOW_PLAYING: "now-playing",
+  LAST_PLAYED: "last-played",
+  ACCESS_TOKEN: "access-token",
+} as const;
+
+/**
+ * Type alias for cache key values
+ * @type {(typeof SPOTIFY_CACHE_KEYS)[keyof typeof SPOTIFY_CACHE_KEYS]} - SpotifyCacheKey
+ */
+export type SpotifyCacheKey =
+  (typeof SPOTIFY_CACHE_KEYS)[keyof typeof SPOTIFY_CACHE_KEYS];

--- a/back/src/domain/spotify/cache_repository.ts
+++ b/back/src/domain/spotify/cache_repository.ts
@@ -5,7 +5,6 @@
 // domain
 import { Result } from "@/domain/common/result.ts";
 import { DomainError } from "@/domain/error/error.ts";
-import { Track } from "@/domain/spotify/track.ts";
 
 /**
  * Cache Repository Interface
@@ -13,48 +12,26 @@ import { Track } from "@/domain/spotify/track.ts";
  */
 export interface CacheRepository {
   /**
-   * Get cached track data
+   * Get cached data
    * @param {string} key - Cache key
    * @param {number} maxAge - Maximum age in milliseconds (optional)
-   * @returns {Promise<Result<{ found: boolean; data: Track | null }, DomainError>>} - Result containing found status and track data or null
+   * @returns {Promise<Result<{ found: boolean; data: unknown }, DomainError>>} - Result containing found status and data
    */
-  getTrack(
+  get(
     key: string,
     maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: Track | null }, DomainError>>;
+  ): Promise<Result<{ found: boolean; data: unknown }, DomainError>>;
 
   /**
-   * Set cached track data
+   * Set cached data
    * @param {string} key - Cache key
-   * @param {Track} track - Track data to cache
+   * @param {unknown} data - Data to cache
+   * @param {number} ttl - Time to live in milliseconds (optional)
    * @returns {Promise<Result<void, DomainError>>} - Result indicating success or failure
    */
-  setTrack(
+  set(
     key: string,
-    track: Track | null,
-  ): Promise<Result<void, DomainError>>;
-
-  /**
-   * Get cached token data
-   * @param {string} key - Cache key
-   * @param {number} maxAge - Maximum age in milliseconds (optional)
-   * @returns {Promise<Result<{ found: boolean; data: string | null }, DomainError>>} - Result containing found status and token data or null
-   */
-  getToken(
-    key: string,
-    maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: string | null }, DomainError>>;
-
-  /**
-   * Set cached token data
-   * @param {string} key - Cache key
-   * @param {string} token - Token data to cache
-   * @param {number} ttl - Time to live in milliseconds
-   * @returns {Promise<Result<void, DomainError>>} - Result indicating success or failure
-   */
-  setToken(
-    key: string,
-    token: string | null,
+    data: unknown,
     ttl?: number,
   ): Promise<Result<void, DomainError>>;
 }

--- a/back/src/domain/spotify/track.ts
+++ b/back/src/domain/spotify/track.ts
@@ -213,4 +213,54 @@ export class Track {
     const date = new Date(timestamp);
     return !isNaN(date.getTime());
   }
+
+  /**
+   * Convert Track to serializable format for caching
+   * @returns {SerializableTrack} - Serializable track data
+   */
+  toSerializable(): SerializableTrack {
+    return {
+      imageUrl: this._imageUrl,
+      trackName: this._trackName,
+      trackUrl: this._trackUrl,
+      albumName: this._albumName,
+      albumUrl: this._albumUrl,
+      artistName: this._artistName,
+      artistUrl: this._artistUrl,
+      playedAt: this._playedAt,
+    };
+  }
+
+  /**
+   * Create Track from serializable format
+   * @param {SerializableTrack} data - Serializable track data
+   * @returns {Track | DomainError} - Track instance or error
+   */
+  static fromSerializable(data: SerializableTrack): Track | DomainError {
+    return this.reconstruct(
+      data.imageUrl,
+      data.trackName,
+      data.trackUrl,
+      data.albumName,
+      data.albumUrl,
+      data.artistName,
+      data.artistUrl,
+      data.playedAt,
+    );
+  }
+}
+
+/**
+ * Serializable track data for cache storage
+ * @interface SerializableTrack
+ */
+export interface SerializableTrack {
+  imageUrl: string;
+  trackName: string;
+  trackUrl: string;
+  albumName: string;
+  albumUrl: string;
+  artistName: string;
+  artistUrl: string;
+  playedAt?: string;
 }

--- a/back/src/infrastructure/cache/cache_service.ts
+++ b/back/src/infrastructure/cache/cache_service.ts
@@ -6,44 +6,18 @@
 import { EnvironmentConfig } from "@/domain/common/environments.ts";
 import { Result } from "@/domain/common/result.ts";
 import { DomainError, ExternalServiceError } from "@/domain/error/error.ts";
-import { CacheRepository } from "@/domain/spotify/cache_repository.ts";
-import { Track } from "@/domain/spotify/track.ts";
 
 import { EnvironmentUtils, getEnvironmentUtils } from "../config/env_utils.ts";
+import { CacheRepository } from "@/domain/spotify/cache_repository.ts";
 
 /**
- * Track Cache entry
- * @interface TrackCacheEntry
+ * Generic cache entry
+ * @interface CacheEntry
  */
-interface TrackCacheEntry {
-  data: TrackData | null;
+interface CacheEntry {
+  data: unknown;
   timestamp: number;
   ttl: number;
-}
-
-/**
- * Token cache entry
- * @interface TokenCacheEntry
- */
-interface TokenCacheEntry {
-  data: string | null;
-  timestamp: number;
-  ttl: number;
-}
-
-/**
- * Serializable track data for cache storage
- * @interface TrackData
- */
-interface TrackData {
-  imageUrl: string;
-  trackName: string;
-  trackUrl: string;
-  albumName: string;
-  albumUrl: string;
-  artistName: string;
-  artistUrl: string;
-  playedAt?: string;
 }
 
 /**
@@ -51,9 +25,8 @@ interface TrackData {
  * @class CacheService
  */
 export class CacheService implements CacheRepository {
-  private static memoryCache = new Map<string, TrackCacheEntry>();
-  private static tokenMemoryCache = new Map<string, TokenCacheEntry>();
-  private readonly ttl: number;
+  private static memoryCache = new Map<string, CacheEntry>();
+  private readonly defaultTtl: number;
   private readonly env: EnvironmentConfig;
   private readonly envUtils: EnvironmentUtils;
 
@@ -64,41 +37,59 @@ export class CacheService implements CacheRepository {
   constructor(env: EnvironmentConfig) {
     this.env = env;
     this.envUtils = getEnvironmentUtils();
-    this.ttl = this.envUtils.getCacheTtlSeconds() * 1000;
+    this.defaultTtl = this.envUtils.getCacheTtlSeconds() * 1000;
   }
 
   /**
-   * Get cached track data
+   * Get cached data
    * @param {string} key - Cache key
-   * @param {number} maxAge - Maximum age in milliseconds
-   * @returns {Promise<Result<{ found: boolean; data: Track | null }, DomainError>>} - Result with cache hit status and track data
+   * @param {number} maxAge - Maximum age in milliseconds (optional)
+   * @returns {Promise<Result<{ found: boolean; data: unknown }, DomainError>>} - Result with cache hit status and data
    */
-  async getTrack(
+  async get(
     key: string,
     maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: Track | null }, DomainError>> {
+  ): Promise<Result<{ found: boolean; data: unknown }, DomainError>> {
     try {
-      // use in-memory cache for local development, hybrid (memory + KV) for others
-      const result = this.envUtils.isLocalDevelopment()
-        ? this.getTrackFromMemory(key, maxAge)
-        : await this.getTrackFromHybrid(key, maxAge);
-      if (result.isOk()) {
-        // log cache hit/miss with cache type
-        const { found, data } = result.unwrap();
-        const cacheType = this.envUtils.isLocalDevelopment()
-          ? "memory"
-          : "hybrid";
+      console.log("Getting cache:", { key, maxAge });
+
+      // always check memory first (all environments)
+      const memoryResult = this.getFromMemory(key, maxAge);
+      if (memoryResult.found) {
+        console.log("Cache: Memory hit");
         console.log("Cache:", {
           key,
-          hit: found,
-          hasData: !!data,
-          type: cacheType,
+          hit: true,
+          hasData: memoryResult.data !== null,
         });
+        return Result.ok(memoryResult);
       }
-      // if cache hit, return data
-      return result;
-    } catch (error) {
-      // if any unexpected error occurs, return an error
+
+      // if not in memory and not local development, check KV
+      if (!this.envUtils.isLocalDevelopment()) {
+        const kvResult = await this.getFromKV(key, maxAge);
+        if (kvResult.found) {
+          // save to memory for faster subsequent access
+          this.setToMemory(key, kvResult.data, this.defaultTtl);
+          console.log("Cache: KV hit, saved to memory");
+          console.log("Cache:", {
+            key,
+            hit: true,
+            hasData: kvResult.data !== null,
+          });
+          return Result.ok(kvResult);
+        }
+      }
+
+      // cache miss
+      console.log("Cache: Complete miss");
+      console.log("Cache:", {
+        key,
+        hit: false,
+        hasData: false,
+      });
+      return Result.ok({ found: false, data: null });
+    } catch (error: unknown) {
       const errorMessage = `Cache get failed: ${
         error instanceof Error ? error.message : String(error)
       }`;
@@ -111,299 +102,44 @@ export class CacheService implements CacheRepository {
   }
 
   /**
-   * Set cached track data
+   * Set cached data
    * @param {string} key - Cache key
-   * @param {Track} track - Track data to cache
-   * @returns {Promise<Result<void, DomainError>>} - Result indicating success or failure
-   */
-  async setTrack(
-    key: string,
-    track: Track | null,
-  ): Promise<Result<void, DomainError>> {
-    try {
-      console.log("Setting track cache:", { key, hasTrack: !!track });
-      // create cache entry
-      const entry: TrackCacheEntry = {
-        data: track ? this.trackToData(track) : null,
-        timestamp: Date.now(),
-        ttl: this.ttl,
-      };
-      // use in-memory cache for local development, KV for others
-      if (this.envUtils.isLocalDevelopment()) {
-        CacheService.memoryCache.set(key, entry);
-        console.log("Track cache set to memory:", { key });
-      } else {
-        const kvNamespace = this.env.YANOPORTFOLIO_BACK_CACHE;
-        if (kvNamespace) {
-          // KV requires minimum 60 seconds TTL
-          const kvTtlSeconds = Math.max(60, Math.floor(this.ttl / 1000));
-          await kvNamespace.put(key, JSON.stringify(entry), {
-            expirationTtl: kvTtlSeconds,
-          });
-          console.log("Track cache set to KV:", { key, ttl: kvTtlSeconds });
-
-          // Also set to memory for immediate access (using configured TTL)
-          CacheService.memoryCache.set(key, {
-            ...entry,
-            ttl: this.ttl,
-          });
-          console.log("Track cache also set to memory:", {
-            key,
-            ttl: this.ttl / 1000,
-          });
-        } else {
-          // fallback to memory if KV not available
-          CacheService.memoryCache.set(key, entry);
-          console.log("Track cache fallback to memory:", { key });
-        }
-      }
-      // if cache set successfully, return success
-      return Result.ok(undefined);
-    } catch (error) {
-      // if any unexpected error occurs, return an error
-      console.error("Track cache set failed:", error);
-      const errorMessage = `Cache set failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
-      // use DomainError for local memory cache, ExternalServiceError for KV
-      return Result.fail(
-        this.envUtils.isLocalDevelopment()
-          ? new DomainError(errorMessage, "CACHE_ERROR")
-          : new ExternalServiceError(errorMessage, "Cloudflare KV"),
-      );
-    }
-  }
-
-  /**
-   * Get track from memory cache
-   * @param {string} key - Cache key
-   * @param {number} [maxAge] - Maximum age in milliseconds
-   * @returns {Result<{ found: boolean; data: Track | null }, DomainError>} - Result with cache hit status and track data
-   */
-  private getTrackFromMemory(
-    key: string,
-    maxAge?: number,
-  ): Result<{ found: boolean; data: Track | null }, DomainError> {
-    // check memory cache
-    const entry = CacheService.memoryCache.get(key);
-    if (!entry) {
-      // if not found, return miss
-      return Result.ok({ found: false, data: null });
-    }
-    // check if entry is expired
-    const now = Date.now();
-    const effectiveTtl = maxAge || entry.ttl;
-    if (now - entry.timestamp > effectiveTtl) {
-      // if expired, delete and return miss
-      CacheService.memoryCache.delete(key);
-      return Result.ok({ found: false, data: null });
-    }
-    // if found and valid, return hit with data
-    const track = entry.data ? this.dataToTrack(entry.data) : null;
-    return Result.ok({ found: true, data: track });
-  }
-
-  /**
-   * Get track from KV cache
-   * @param {string} key - Cache key
-   * @param {number} [maxAge] - Maximum age in milliseconds
-   * @returns {Promise<Result<{ found: boolean; data: Track | null }, DomainError>>} - Result with cache hit status and track data
-   */
-  private async getTrackFromKV(
-    key: string,
-    maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: Track | null }, DomainError>> {
-    // check KV cache
-    const kvNamespace = this.env.YANOPORTFOLIO_BACK_CACHE;
-    if (!kvNamespace) {
-      // fallback to memory
-      console.log("KV unavailable, falling back to memory cache");
-      return this.getTrackFromMemory(key, maxAge);
-    }
-    // if KV is available, get entry
-    const cached = await kvNamespace.get(key, { type: "json" });
-    if (!cached) {
-      // if not found, return miss
-      return Result.ok({ found: false, data: null });
-    }
-    // check if entry is expired
-    const entry = cached as TrackCacheEntry;
-    const now = Date.now();
-    const effectiveTtl = maxAge || entry.ttl;
-    if (now - entry.timestamp > effectiveTtl) {
-      // if expired, delete and return miss
-      await kvNamespace.delete(key);
-      return Result.ok({ found: false, data: null });
-    }
-    // if found and valid, return hit with data
-    const track = entry.data ? this.dataToTrack(entry.data) : null;
-    return Result.ok({ found: true, data: track });
-  }
-
-  /**
-   * Get track from hybrid cache (Memory + KV with SWR)
-   * @param {string} key - Cache key
-   * @param {number} [maxAge] - Maximum age in milliseconds
-   * @returns {Promise<Result<{ found: boolean; data: Track | null }, DomainError>>} - Result with cache hit status and track data
-   */
-  private async getTrackFromHybrid(
-    key: string,
-    maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: Track | null }, DomainError>> {
-    // check memory cache first (fast, using configured TTL)
-    const memoryResult = this.getTrackFromMemory(key, this.ttl);
-    if (memoryResult.isOk() && memoryResult.unwrap().found) {
-      console.log("Hybrid cache: Memory hit");
-      return memoryResult;
-    }
-    // check KV cache (slower, 60 second TTL minimum)
-    const kvResult = await this.getTrackFromKV(key, maxAge);
-    if (kvResult.isOk() && kvResult.unwrap().found) {
-      const { data } = kvResult.unwrap();
-      // save to memory cache for faster subsequent access
-      if (data) {
-        const entry: TrackCacheEntry = {
-          data: this.trackToData(data),
-          timestamp: Date.now(),
-          ttl: this.ttl,
-        };
-        CacheService.memoryCache.set(key, entry);
-        console.log("Hybrid cache: KV hit, saved to memory");
-      }
-      return kvResult;
-    }
-    // cache miss - return not found
-    console.log("Hybrid cache: Complete miss");
-    return Result.ok({ found: false, data: null });
-  }
-
-  /**
-   * Convert Track domain object to serializable data
-   * @param {Track} track - Track domain object
-   * @returns {TrackData} - Serializable data
-   */
-  private trackToData(track: Track): TrackData {
-    return {
-      imageUrl: track.imageUrl(),
-      trackName: track.trackName(),
-      trackUrl: track.trackUrl(),
-      albumName: track.albumName(),
-      albumUrl: track.albumUrl(),
-      artistName: track.artistName(),
-      artistUrl: track.artistUrl(),
-      playedAt: track.playedAt(),
-    };
-  }
-
-  /**
-   * Convert serializable data to Track domain object
-   * @param {TrackData} data - Serializable data
-   * @returns {Track | null} - Track domain object or null
-   */
-  private dataToTrack(data: TrackData): Track | null {
-    const trackResult = Track.reconstruct(
-      data.imageUrl,
-      data.trackName,
-      data.trackUrl,
-      data.albumName,
-      data.albumUrl,
-      data.artistName,
-      data.artistUrl,
-      data.playedAt,
-    );
-    if (trackResult instanceof DomainError) {
-      // log error but return null - cache corruption scenario
-      console.warn("Cache data corruption detected:", trackResult.message);
-      return null;
-    }
-    // otherwise return reconstructed track
-    return trackResult;
-  }
-
-  /**
-   * Get cached token data
-   * @param {string} key - Cache key
-   * @param {number} maxAge - Maximum age in milliseconds (optional)
-   * @returns {Promise<Result<{ found: boolean; data: string | null }, DomainError>>} - Result with cache hit status and token data
-   */
-  async getToken(
-    key: string,
-    maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: string | null }, DomainError>> {
-    try {
-      // use in-memory cache for local development, KV for others
-      const result = this.envUtils.isLocalDevelopment()
-        ? this.getTokenFromMemory(key, maxAge)
-        : await this.getTokenFromKV(key, maxAge);
-      if (result.isOk()) {
-        // log cache hit/miss with cache type
-        const { found, data } = result.unwrap();
-        const cacheType = this.envUtils.isLocalDevelopment() ? "memory" : "KV";
-        console.log("Token Cache:", {
-          key,
-          hit: found,
-          hasData: !!data,
-          type: cacheType,
-        });
-      }
-      // if cache hit, return data
-      return result;
-    } catch (error) {
-      // if any unexpected error occurs, return an error
-      const errorMessage = `Token cache get failed: ${
-        error instanceof Error ? error.message : String(error)
-      }`;
-      // use DomainError for local memory cache, ExternalServiceError for KV
-      return Result.fail(
-        this.envUtils.isLocalDevelopment()
-          ? new DomainError(errorMessage, "CACHE_ERROR")
-          : new ExternalServiceError(errorMessage, "Cloudflare KV"),
-      );
-    }
-  }
-
-  /**
-   * Set cached token data
-   * @param {string} key - Cache key
-   * @param {string} token - Token data to cache
+   * @param {unknown} data - Data to cache
    * @param {number} ttl - Time to live in milliseconds (optional)
    * @returns {Promise<Result<void, DomainError>>} - Result indicating success or failure
    */
-  async setToken(
+  async set(
     key: string,
-    token: string | null,
+    data: unknown,
     ttl?: number,
   ): Promise<Result<void, DomainError>> {
+    console.log("Setting cache:", { key, hasData: data !== null });
     try {
-      // create token cache entry
-      const entry: TokenCacheEntry = {
-        data: token,
-        timestamp: Date.now(),
-        ttl: ttl || this.ttl,
-      };
-      // use in-memory cache for local development, KV for others
-      if (this.envUtils.isLocalDevelopment()) {
-        CacheService.tokenMemoryCache.set(key, entry);
-      } else {
-        const kvNamespace = this.env.YANOPORTFOLIO_BACK_CACHE;
-        if (kvNamespace) {
-          // if KV is available, set entry with key
-          await kvNamespace.put(key, JSON.stringify(entry), {
-            expirationTtl: Math.floor((ttl || this.ttl) / 1000),
-          });
+      const effectiveTtl = ttl || this.defaultTtl;
+
+      // always set to memory cache first (all environments)
+      this.setToMemory(key, data, effectiveTtl);
+      console.log("Cache set to memory");
+
+      // additionally set to KV in production
+      if (!this.envUtils.isLocalDevelopment()) {
+        const kvResult = await this.setToKV(key, data, effectiveTtl);
+        if (kvResult) {
+          console.log("Cache also set to KV");
         } else {
-          // fallback to memory if KV not available
-          CacheService.tokenMemoryCache.set(key, entry);
+          console.warn(
+            "Failed to set cache to KV, but memory succeeded:",
+            key,
+          );
         }
       }
-      // if cache set successfully, return success
+
       return Result.ok(undefined);
-    } catch (error) {
-      // if any unexpected error occurs, return an error
-      const errorMessage = `Token cache set failed: ${
+    } catch (error: unknown) {
+      console.error("Cache set failed:", error);
+      const errorMessage = `Cache set failed: ${
         error instanceof Error ? error.message : String(error)
       }`;
-      // use DomainError for local memory cache, ExternalServiceError for KV
       return Result.fail(
         this.envUtils.isLocalDevelopment()
           ? new DomainError(errorMessage, "CACHE_ERROR")
@@ -413,66 +149,115 @@ export class CacheService implements CacheRepository {
   }
 
   /**
-   * Get token from memory cache
+   * Get data from memory cache
    * @param {string} key - Cache key
    * @param {number} [maxAge] - Maximum age in milliseconds
-   * @returns {Result<{ found: boolean; data: string | null }, DomainError>} - Result with cache hit status and token data
+   * @returns {{ found: boolean; data: unknown }} - Cache hit status and data
    */
-  private getTokenFromMemory(
+  private getFromMemory(
     key: string,
     maxAge?: number,
-  ): Result<{ found: boolean; data: string | null }, DomainError> {
-    // check memory cache
-    const entry = CacheService.tokenMemoryCache.get(key);
+  ): { found: boolean; data: unknown } {
+    const entry = CacheService.memoryCache.get(key);
     if (!entry) {
-      // if not found, return miss
-      return Result.ok({ found: false, data: null });
+      return { found: false, data: null };
     }
-    // check if entry is expired
+
     const now = Date.now();
     const effectiveTtl = maxAge || entry.ttl;
     if (now - entry.timestamp > effectiveTtl) {
-      // if expired, delete and return miss
-      CacheService.tokenMemoryCache.delete(key);
-      return Result.ok({ found: false, data: null });
+      CacheService.memoryCache.delete(key);
+      return { found: false, data: null };
     }
-    // if found and valid, return hit with data
-    return Result.ok({ found: true, data: entry.data });
+
+    return { found: true, data: entry.data };
   }
 
   /**
-   * Get token from KV cache
+   * Get data from KV cache
    * @param {string} key - Cache key
    * @param {number} [maxAge] - Maximum age in milliseconds
-   * @returns {Promise<Result<{ found: boolean; data: string | null }, DomainError>>} - Result with cache hit status and token data
+   * @returns {Promise<{ found: boolean; data: unknown }>} - Cache hit status and data
    */
-  private async getTokenFromKV(
+  private async getFromKV(
     key: string,
     maxAge?: number,
-  ): Promise<Result<{ found: boolean; data: string | null }, DomainError>> {
-    // check KV cache
+  ): Promise<{ found: boolean; data: unknown }> {
     const kvNamespace = this.env.YANOPORTFOLIO_BACK_CACHE;
     if (!kvNamespace) {
-      // fallback to memory
-      console.log("KV unavailable for token, falling back to memory cache");
-      return this.getTokenFromMemory(key, maxAge);
+      return { found: false, data: null };
     }
-    // if KV is available, get entry with key
+
     const cached = await kvNamespace.get(key, { type: "json" });
     if (!cached) {
-      // if not found, return miss
-      return Result.ok({ found: false, data: null });
+      return { found: false, data: null };
     }
-    // check if entry is expired
-    const entry = cached as TokenCacheEntry;
+
+    const entry = cached as CacheEntry;
     const now = Date.now();
     const effectiveTtl = maxAge || entry.ttl;
     if (now - entry.timestamp > effectiveTtl) {
-      // if expired, delete and return miss
       await kvNamespace.delete(key);
-      return Result.ok({ found: false, data: null });
+      return { found: false, data: null };
     }
-    // if found and valid, return hit with data
-    return Result.ok({ found: true, data: entry.data });
+
+    return { found: true, data: entry.data };
+  }
+
+  /**
+   * Set data to memory cache
+   * @param {string} key - Cache key
+   * @param {unknown} data - Data to cache
+   * @param {number} ttl - Time to live in milliseconds
+   */
+  private setToMemory(
+    key: string,
+    data: unknown,
+    ttl: number,
+  ): void {
+    const entry: CacheEntry = {
+      data,
+      timestamp: Date.now(),
+      ttl,
+    };
+    CacheService.memoryCache.set(key, entry);
+    console.log("Set to memory cache:", { key });
+  }
+
+  /**
+   * Set data to KV cache
+   * @param {string} key - Cache key
+   * @param {unknown} data - Data to cache
+   * @param {number} ttl - Time to live in milliseconds
+   * @returns {Promise<boolean>} - Success status
+   */
+  private async setToKV(
+    key: string,
+    data: unknown,
+    ttl: number,
+  ): Promise<boolean> {
+    const kvNamespace = this.env.YANOPORTFOLIO_BACK_CACHE;
+    if (!kvNamespace) {
+      console.log("KV unavailable, fallback to memory only");
+      return false;
+    }
+
+    try {
+      const entry: CacheEntry = {
+        data,
+        timestamp: Date.now(),
+        ttl,
+      };
+
+      // KV requires minimum 60 seconds TTL
+      const kvTtlSeconds = Math.max(60, Math.floor(ttl / 1000));
+      await kvNamespace.put(key, JSON.stringify(entry), {
+        expirationTtl: kvTtlSeconds,
+      });
+      console.log("Set to KV cache:", { key, ttl: kvTtlSeconds });
+      return true;
+    } catch {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
- add `SPOTIFY_CACHE_KEYS` constants for consistent key management
- replace specific `getTrack`/`setTrack`/`getToken`/`setToken` methods with generic `get`/`set` methods in `CacheRepository` interface
- add `toSerializable`/`fromSerializable` methods to `Track` class for cache storage
- update `SpotifyApiClient` to use new cache interface with track serialization
- update `OAuthService` to use generic cache methods for token storage
- consolidate memory and KV cache logic in `CacheService`
- improve cache logging and error handling