### PR TITLE
✨feat(cache): add optional KV storage usage control

### DIFF
--- a/back/src/domain/spotify/cache_repository.ts
+++ b/back/src/domain/spotify/cache_repository.ts
@@ -15,11 +15,13 @@ export interface CacheRepository {
    * Get cached data
    * @param {string} key - Cache key
    * @param {number} maxAge - Maximum age in milliseconds (optional)
+   * @param {boolean} useKV - Use KV storage in addition to memory cache (optional, defaults to false)
    * @returns {Promise<Result<{ found: boolean; data: unknown }, DomainError>>} - Result containing found status and data
    */
   get(
     key: string,
     maxAge?: number,
+    useKV?: boolean,
   ): Promise<Result<{ found: boolean; data: unknown }, DomainError>>;
 
   /**
@@ -27,11 +29,13 @@ export interface CacheRepository {
    * @param {string} key - Cache key
    * @param {unknown} data - Data to cache
    * @param {number} ttl - Time to live in milliseconds (optional)
+   * @param {boolean} useKV - Use KV storage in addition to memory cache (optional, defaults to false)
    * @returns {Promise<Result<void, DomainError>>} - Result indicating success or failure
    */
   set(
     key: string,
     data: unknown,
     ttl?: number,
+    useKV?: boolean,
   ): Promise<Result<void, DomainError>>;
 }

--- a/back/src/infrastructure/api/spotify_api_client.ts
+++ b/back/src/infrastructure/api/spotify_api_client.ts
@@ -216,7 +216,10 @@ export class SpotifyApiClient implements TrackRepository {
         });
         // 204 means no content, i.e. nothing is currently playing
         if (response.status === 204) {
-          await this.cacheRepository.set(SPOTIFY_CACHE_KEYS.NOW_PLAYING, null);
+          await this.cacheRepository.set(
+            SPOTIFY_CACHE_KEYS.NOW_PLAYING,
+            null,
+          );
           return Result.ok(null);
         }
         // handle other non-200 responses
@@ -304,7 +307,10 @@ export class SpotifyApiClient implements TrackRepository {
         );
         // 204 means no content, i.e. nothing is last played
         if (response.status === 204) {
-          await this.cacheRepository.set(SPOTIFY_CACHE_KEYS.LAST_PLAYED, null);
+          await this.cacheRepository.set(
+            SPOTIFY_CACHE_KEYS.LAST_PLAYED,
+            null,
+          );
           return Result.ok(null);
         }
         // handle other non-200 responses
@@ -319,7 +325,10 @@ export class SpotifyApiClient implements TrackRepository {
         // parse response
         const data = (await response.json()) as SpotifyRecentlyPlayed;
         if (!data.items || data.items.length === 0) {
-          await this.cacheRepository.set(SPOTIFY_CACHE_KEYS.LAST_PLAYED, null);
+          await this.cacheRepository.set(
+            SPOTIFY_CACHE_KEYS.LAST_PLAYED,
+            null,
+          );
           return Result.ok(null);
         }
         const lastPlayedItem = data.items[0];
@@ -327,7 +336,7 @@ export class SpotifyApiClient implements TrackRepository {
           lastPlayedItem.track,
           lastPlayedItem.played_at,
         );
-
+        // handle potential mapping errors
         if (trackResult.isOk()) {
           // if mapping succeeded, cache and return the track
           const track = trackResult.unwrap();
@@ -370,10 +379,9 @@ export class SpotifyApiClient implements TrackRepository {
   ): Result<Track, DomainError> {
     try {
       // get the largest available image
-      const imageUrl =
-        spotifyTrack.album.images.length > 0
-          ? spotifyTrack.album.images[0].url
-          : "";
+      const imageUrl = spotifyTrack.album.images.length > 0
+        ? spotifyTrack.album.images[0].url
+        : "";
       // get primary artist
       const primaryArtist = spotifyTrack.artists[0];
       // format playedAt to yyyy/MM/dd HH:mm:ss format in JST if available
@@ -400,7 +408,8 @@ export class SpotifyApiClient implements TrackRepository {
           2,
           "0",
         );
-        formattedPlayedAt = `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`;
+        formattedPlayedAt =
+          `${year}/${month}/${day} ${hours}:${minutes}:${seconds}`;
       }
       // reconstruct domain track entity
       const trackResult = Track.reconstruct(


### PR DESCRIPTION
- add `useKV` parameter to `CacheRepository` interface methods
- update `CacheService` to support memory-only mode by default
- modify spotify access token caching to use KV storage
- change spotify track caching to memory-only mode
- update oauth service to explicitly enable KV for token caching
- maintain backward compatibility with optional parameter
- improve cache behavior documentation and logging
- avoid cloudflare free plan KV usage limits by selective KV usage