### PR TITLE
🚀perf(back): reduce PBKDF2 iterations for faster encryption

### DIFF
--- a/back/src/infrastructure/security/encryption_service.ts
+++ b/back/src/infrastructure/security/encryption_service.ts
@@ -18,7 +18,7 @@ export class EncryptionService implements EncryptionRepository {
   private static readonly KEY_LENGTH = 256;
   private static readonly IV_LENGTH = 12;
   private static readonly SALT_LENGTH = 16;
-  private static readonly PBKDF2_ITERATIONS = 100000;
+  private static readonly PBKDF2_ITERATIONS = 10000;
   private readonly envUtils = getEnvironmentUtils();
 
   /**


### PR DESCRIPTION
- reduce `PBKDF2_ITERATIONS` from 100,000 to 10,000 to optimize performance and prevent CPU time limit exceeded errors in cloudflare workers
- maintain sufficient security level for short-lived spotify tokens
- improve response time for all spotify endpoints