### PR TITLE
🐞fix(front): remove trailing slashes from generated URLs

### DIFF
--- a/front/astro.config.mjs
+++ b/front/astro.config.mjs
@@ -7,6 +7,10 @@ import tailwind from "@astrojs/tailwind";
 
 export default defineConfig({
   output: "static",
+  trailingSlash: "never",
+  build: {
+    format: "file"
+  },
   integrations: [
     icon(),
     mdx(),


### PR DESCRIPTION
- add `trailingSlash: "never"` configuration to prevent automatic trailing slash addition to URLs
- add `build.format: "file"` to generate direct HTML files instead of directory structure with index.html files
- fix issue where URLs like `/about` were automatically redirected to `/about/` on Cloudflare Pages