### PR TITLE
🔧refactor(back): serialize console log outputs for consistency

### DIFF
--- a/back/src/infrastructure/api/spotify_api_client.ts
+++ b/back/src/infrastructure/api/spotify_api_client.ts
@@ -199,7 +199,10 @@ export class SpotifyApiClient implements TrackRepository {
           cacheData.data as SerializableTrack,
         );
         if (trackResult instanceof DomainError) {
-          console.warn("Cache data corruption detected:", trackResult.message);
+          console.warn(
+            "Cache data corruption detected:",
+            JSON.stringify({ message: trackResult.message }),
+          );
           // continue to fetch from API
         } else {
           return Result.ok(trackResult);
@@ -237,7 +240,10 @@ export class SpotifyApiClient implements TrackRepository {
         if (trackResult.isOk()) {
           // if mapping succeeded, cache and return the track
           const track = trackResult.unwrap();
-          console.log("Spotify now-playing success:", { track });
+          console.log(
+            "Spotify now-playing success:",
+            JSON.stringify({ track: track.toSerializable() }),
+          );
           await this.cacheRepository.set(
             SPOTIFY_CACHE_KEYS.NOW_PLAYING,
             track.toSerializable(),
@@ -287,7 +293,10 @@ export class SpotifyApiClient implements TrackRepository {
           cacheData.data as SerializableTrack,
         );
         if (trackResult instanceof DomainError) {
-          console.warn("Cache data corruption detected:", trackResult.message);
+          console.warn(
+            "Cache data corruption detected:",
+            JSON.stringify({ message: trackResult.message }),
+          );
           // continue to fetch from API
         } else {
           return Result.ok(trackResult);
@@ -340,7 +349,10 @@ export class SpotifyApiClient implements TrackRepository {
         if (trackResult.isOk()) {
           // if mapping succeeded, cache and return the track
           const track = trackResult.unwrap();
-          console.log("Spotify last-played success:", { track });
+          console.log(
+            "Spotify last-played success:",
+            JSON.stringify({ track: track.toSerializable() }),
+          );
           await this.cacheRepository.set(
             SPOTIFY_CACHE_KEYS.LAST_PLAYED,
             track.toSerializable(),

--- a/back/src/infrastructure/cache/cache_service.ts
+++ b/back/src/infrastructure/cache/cache_service.ts
@@ -62,7 +62,10 @@ export class CacheService implements CacheRepository {
     needDecryption = false,
   ): Promise<Result<{ found: boolean; data: unknown }, DomainError>> {
     try {
-      console.log("Getting cache:", { key, maxAge, useKV, needDecryption });
+      console.log(
+        "Getting cache:",
+        JSON.stringify({ key, maxAge, useKV, needDecryption }),
+      );
       // always check memory first (all environments)
       const memoryResult = this.getFromMemory(key, maxAge);
       if (memoryResult.found) {
@@ -88,7 +91,10 @@ export class CacheService implements CacheRepository {
               ok: () => null,
               fail: (err) => err,
             });
-            console.error("Cache: Failed to decrypt memory data:", error);
+            console.error(
+              "Cache: Failed to decrypt memory data:",
+              error instanceof DomainError ? error.message : String(error),
+            );
             return Result.fail(error!);
           }
           // successfully decrypted
@@ -97,11 +103,14 @@ export class CacheService implements CacheRepository {
           console.log("Cache: Memory hit, data decrypted");
         }
         // return decrypted data from memory
-        console.log("Cache:", {
-          key,
-          hit: true,
-          hasData: memoryResult.data !== null,
-        });
+        console.log(
+          "Cache:",
+          JSON.stringify({
+            key,
+            hit: true,
+            hasData: memoryResult.data !== null,
+          }),
+        );
         return Result.ok(memoryResult);
       }
       // if not in memory and not local development, check KV (only if useKV is true)
@@ -131,7 +140,10 @@ export class CacheService implements CacheRepository {
                 ok: () => null,
                 fail: (err) => err,
               });
-              console.error("Cache: Failed to decrypt KV data:", error);
+              console.error(
+                "Cache: Failed to decrypt KV data:",
+                error instanceof DomainError ? error.message : String(error),
+              );
               return Result.fail(error!);
             }
             // successfully decrypted
@@ -144,21 +156,27 @@ export class CacheService implements CacheRepository {
           this.setToMemory(key, kvResult.data, this.defaultTtl);
           console.log("Cache: Saved KV data to memory");
           // return decrypted data from KV
-          console.log("Cache:", {
-            key,
-            hit: true,
-            hasData: kvResult.data !== null,
-          });
+          console.log(
+            "Cache:",
+            JSON.stringify({
+              key,
+              hit: true,
+              hasData: kvResult.data !== null,
+            }),
+          );
           return Result.ok(kvResult);
         }
       }
       // cache miss
       console.log("Cache: Complete miss");
-      console.log("Cache:", {
-        key,
-        hit: false,
-        hasData: false,
-      });
+      console.log(
+        "Cache:",
+        JSON.stringify({
+          key,
+          hit: false,
+          hasData: false,
+        }),
+      );
       return Result.ok({ found: false, data: null });
     } catch (error: unknown) {
       // if any unexpected error occurs, pass through the error
@@ -189,12 +207,15 @@ export class CacheService implements CacheRepository {
     useKV = false,
     useEncryption = false,
   ): Promise<Result<void, DomainError>> {
-    console.log("Setting cache:", {
-      key,
-      hasData: data !== null,
-      useKV,
-      useEncryption,
-    });
+    console.log(
+      "Setting cache:",
+      JSON.stringify({
+        key,
+        hasData: data !== null,
+        useKV,
+        useEncryption,
+      }),
+    );
     try {
       const effectiveTtl = ttl || this.defaultTtl;
       if (useEncryption) {
@@ -217,7 +238,10 @@ export class CacheService implements CacheRepository {
             ok: () => null,
             fail: (err) => err,
           });
-          console.error("Failed to encrypt sensitive data:", error);
+          console.error(
+            "Failed to encrypt sensitive data:",
+            error instanceof DomainError ? error.message : String(error),
+          );
           return Result.fail(error!);
         }
         // use encrypted string for storage
@@ -242,7 +266,7 @@ export class CacheService implements CacheRepository {
           // failed to set to KV, but memory succeeded
           console.warn(
             "Failed to set cache to KV, but memory succeeded:",
-            key,
+            JSON.stringify({ key }),
           );
         }
       } else if (!useKV) {
@@ -252,7 +276,10 @@ export class CacheService implements CacheRepository {
       return Result.ok(undefined);
     } catch (error: unknown) {
       // if any unexpected error occurs, pass through the error
-      console.error("Cache set failed:", error);
+      console.error(
+        "Cache set failed:",
+        error instanceof Error ? error.message : String(error),
+      );
       const errorMessage = `Cache set failed: ${
         error instanceof Error ? error.message : String(error)
       }`;
@@ -345,7 +372,7 @@ export class CacheService implements CacheRepository {
       ttl,
     };
     CacheService.memoryCache.set(key, entry);
-    console.log("Set to memory cache:", { key, ttl });
+    console.log("Set to memory cache:", JSON.stringify({ key, ttl }));
   }
 
   /**
@@ -380,7 +407,10 @@ export class CacheService implements CacheRepository {
       await kvNamespace.put(key, JSON.stringify(entry), {
         expirationTtl: kvTtlSeconds,
       });
-      console.log("Set to KV cache:", { key, ttl: kvTtlSeconds });
+      console.log(
+        "Set to KV cache:",
+        JSON.stringify({ key, ttl: kvTtlSeconds }),
+      );
       // succeeded to set to KV
       return true;
     } catch {

--- a/back/src/infrastructure/oauth/oauth_service.ts
+++ b/back/src/infrastructure/oauth/oauth_service.ts
@@ -141,9 +141,12 @@ export class OAuthService implements TokenRepository {
         scope: tokenResponse.scope,
       };
       // log success
-      console.log("Token refresh success:", {
-        expiresIn: tokenResponse.expires_in,
-      });
+      console.log(
+        "Token refresh success:",
+        JSON.stringify({
+          expiresIn: tokenResponse.expires_in,
+        }),
+      );
       // cache the new token with buffer time to prevent expiration issues
       const bufferTimeMs = this.envUtils.getTokenBufferTimeMs();
       const tokenTtl = tokenData.expiresIn

--- a/back/src/infrastructure/security/encryption_service.ts
+++ b/back/src/infrastructure/security/encryption_service.ts
@@ -110,7 +110,10 @@ export class EncryptionService implements EncryptionRepository {
       return Result.ok(base64);
     } catch (error) {
       // if any error occurs, return failure
-      console.error("Encryption failed:", error);
+      console.error(
+        "Encryption failed:",
+        error instanceof Error ? error.message : String(error),
+      );
       return Result.fail(
         new DomainError(
           `Encryption failed: ${
@@ -169,7 +172,10 @@ export class EncryptionService implements EncryptionRepository {
       return Result.ok(plaintext);
     } catch (error) {
       // if any error occurs, return failure
-      console.error("Decryption failed:", error);
+      console.error(
+        "Decryption failed:",
+        error instanceof Error ? error.message : String(error),
+      );
       return Result.fail(
         new DomainError(
           `Decryption failed: ${

--- a/back/src/main.ts
+++ b/back/src/main.ts
@@ -31,7 +31,10 @@ export default {
       getEnvironmentUtils().validateAllEnvironment();
     } catch (error) {
       // return error if any required environment variable is missing
-      console.error("Missing required environment variables:", error);
+      console.error(
+        "Missing required environment variables:",
+        error instanceof Error ? error.message : String(error),
+      );
       return new Response(
         JSON.stringify({
           error: "Missing Required Environment Variables",
@@ -51,7 +54,10 @@ export default {
       return await routes.handle(request);
     } catch (error) {
       // log and return error if any unhandled exception occurs
-      console.error("Unhandled error:", error);
+      console.error(
+        "Unhandled error:",
+        error instanceof Error ? error.message : String(error),
+      );
       return new Response(
         JSON.stringify({
           error: "Internal Server Error",

--- a/back/src/presentation/routes/routes.ts
+++ b/back/src/presentation/routes/routes.ts
@@ -48,7 +48,7 @@ export class Routes {
     const url = new URL(request.url);
     const path = url.pathname;
     const method = request.method;
-    console.log("Request:", { method, path });
+    console.log("Request:", JSON.stringify({ method, path }));
     // handle CORS preflight
     if (method === "OPTIONS") {
       return this.corsMiddleware.handlePreflight(request);
@@ -68,12 +68,15 @@ export class Routes {
     );
     // performance log
     const duration = Math.round(performance.now() - startTime);
-    console.log("Response:", {
-      method,
-      path,
-      status: finalResponse.status,
-      duration,
-    });
+    console.log(
+      "Response:",
+      JSON.stringify({
+        method,
+        path,
+        status: finalResponse.status,
+        duration,
+      }),
+    );
     // return final response
     return finalResponse;
   }

--- a/back/src/presentation/spotify/handler.ts
+++ b/back/src/presentation/spotify/handler.ts
@@ -61,7 +61,10 @@ export class SpotifyHandler {
       });
     } catch (error) {
       // if any unexpected error occurs, log it and return 500
-      console.error("SpotifyHandler.handleGetNowPlaying error:", error);
+      console.error(
+        "SpotifyHandler.handleGetNowPlaying error:",
+        error instanceof Error ? error.message : String(error),
+      );
       return createErrorResponse("Internal server error");
     }
   }
@@ -102,7 +105,10 @@ export class SpotifyHandler {
       });
     } catch (error) {
       // if any unexpected error occurs, log it and return 500
-      console.error("SpotifyHandler.handleGetLastPlayed error:", error);
+      console.error(
+        "SpotifyHandler.handleGetLastPlayed error:",
+        error instanceof Error ? error.message : String(error),
+      );
       return createErrorResponse("Internal server error");
     }
   }


### PR DESCRIPTION
- use `JSON.stringify()` for object logging across all services
- convert error objects to strings using `error.message` or
  `String(error)`
- ensure consistent log format in spotify api client
- ensure consistent log format in cache service
- ensure consistent log format in oauth service
- ensure consistent log format in encryption service
- ensure consistent log format in main entry point
- ensure consistent log format in routes handler
- ensure consistent log format in spotify handler
