### PR TITLE
🐞fix:(front) fix SPA router edge cases

### DIFF
--- a/front/src/_includes/BaseLayout.tsx
+++ b/front/src/_includes/BaseLayout.tsx
@@ -36,14 +36,15 @@ export default (
         />
         {/* title */}
         <title>{title ? `${title} | ${site.name}` : site.name}</title>
-        {/* FOUC prevention: hide page until CSS loads */}
+        {/* FOUC prevention: hide content until CSS loads, set canvas bg per theme */}
         <style
           dangerouslySetInnerHTML={{
-            __html: "html{visibility:hidden;opacity:0;}",
+            __html:
+              "html{visibility:hidden;opacity:0;background-color:#fdf6e3;color-scheme:light}html.dark{background-color:#2d353b;color-scheme:dark}",
           }}
         >
         </style>
-        {/* critical theme init: must be inline to avoid flash during view transitions */}
+        {/* critical theme init: must be inline to run before first paint */}
         <script
           dangerouslySetInnerHTML={{
             __html:

--- a/front/src/assets/scripts/terminal/core/index.ts
+++ b/front/src/assets/scripts/terminal/core/index.ts
@@ -16,6 +16,7 @@ export {
 export { handleAutocomplete } from "./autocomplete.ts";
 export { executeCommand } from "./executor.ts";
 export {
+  clearRedirectCountdown,
   getPromptHtml,
   isDesktop,
   redirectWithCountdown,

--- a/front/src/assets/scripts/terminal/index.ts
+++ b/front/src/assets/scripts/terminal/index.ts
@@ -9,6 +9,7 @@ import * as commands from "./commands/index.ts";
 // core
 import {
   addCommandToHistory,
+  clearRedirectCountdown,
   executeCommand,
   getNextCommand,
   getPreviousCommand,
@@ -20,6 +21,7 @@ import {
 } from "./core/index.ts";
 import {
   addStdinLine,
+  cancelStdinMode,
   finishStdinMode,
   isStdinModeActive,
 } from "./core/stdin.ts";
@@ -384,6 +386,8 @@ if (document.readyState === "loading") {
 // reinitialize on SPA navigation
 document.addEventListener("app:navigate", () => {
   cleanupTerminal();
+  cancelStdinMode();
+  clearRedirectCountdown();
   if (document.getElementById("terminal-form")) {
     initTerminal();
   }

--- a/front/src/assets/styles/components/router.css
+++ b/front/src/assets/styles/components/router.css
@@ -1,14 +1,28 @@
 /**
  * SPA Router View Transitions
- * Scoped to #main-content for client-side navigation
+ * Elements with view-transition-name become independent layers during
+ * transitions, preserving their stacking order (z-index).
  */
 
 #main-content {
   view-transition-name: main-content;
 }
 
+#spotify-status-container {
+  view-transition-name: spotify-widget;
+}
+
 ::view-transition-old(main-content),
 ::view-transition-new(main-content) {
   animation-duration: var(--duration-normal);
   animation-timing-function: var(--ease-smooth);
+}
+
+/* spotify widget does not change across pages — skip transition entirely */
+::view-transition-old(spotify-widget) {
+  display: none;
+}
+
+::view-transition-new(spotify-widget) {
+  animation: none;
 }


### PR DESCRIPTION
- add `isNavigating` lock to prevent overlapping
  navigations on rapid clicks
- check `event.defaultPrevented` in `shouldIntercept`
  to respect other handlers
- cancel `stdinMode` on SPA navigation in terminal
- clear `redirectWithCountdown` interval on SPA
  navigation to prevent stale `app:requestNavigate`
- add `background-color` and `color-scheme` to inline
  FOUC prevention style to fix dark mode flash on
  initial load
- add `view-transition-name` for Spotify widget to
  preserve z-index during transitions
- hide old Spotify snapshot with `display: none` to
  prevent shadow doubling during cross-fade
