### PR TITLE
🐞fix:(front) fix dark mode FOUC on page load

### DIFF
--- a/front/src/_includes/BaseLayout.tsx
+++ b/front/src/_includes/BaseLayout.tsx
@@ -34,24 +34,26 @@ export default (
           content="#2d353b"
           media="(prefers-color-scheme: dark)"
         />
+        {/* hint browser to use system-preferred canvas color before any CSS */}
+        <meta name="color-scheme" content="dark light" />
         {/* title */}
         <title>{title ? `${title} | ${site.name}` : site.name}</title>
+        {/* critical theme init: must run BEFORE styles to set class and color-scheme */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html:
+              `(function(){var d=document.documentElement;try{var t=localStorage.getItem("theme")}catch(e){var t=null}if(!t)t=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";if(t==="dark"){d.classList.add("dark");d.style.colorScheme="dark"}else{d.style.colorScheme="light"}})()`,
+          }}
+        >
+        </script>
         {/* FOUC prevention: hide content until CSS loads, set canvas bg per theme */}
         <style
           dangerouslySetInnerHTML={{
             __html:
-              "html{visibility:hidden;opacity:0;background-color:#fdf6e3;color-scheme:light}html.dark{background-color:#2d353b;color-scheme:dark}",
+              "html{visibility:hidden;opacity:0;background-color:#fdf6e3}html.dark{background-color:#2d353b}",
           }}
         >
         </style>
-        {/* critical theme init: must be inline to run before first paint */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html:
-              `(function(){try{var t=localStorage.getItem("theme");if(!t)t=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";if(t==="dark")document.documentElement.classList.add("dark")}catch(e){}})()`,
-          }}
-        >
-        </script>
         {/* styles */}
         <link rel="stylesheet" href="/assets/styles/main.css" />
         {/* RSS feed */}

--- a/front/src/assets/scripts/theme/index.ts
+++ b/front/src/assets/scripts/theme/index.ts
@@ -22,11 +22,13 @@ const getCurrentTheme = (): Theme => {
  * @param theme - The theme to apply
  */
 const applyTheme = (theme: Theme): void => {
+  const root = document.documentElement;
   if (theme === THEME_CONFIG.DARK) {
-    document.documentElement.classList.add("dark");
+    root.classList.add("dark");
   } else {
-    document.documentElement.classList.remove("dark");
+    root.classList.remove("dark");
   }
+  root.style.colorScheme = theme;
 };
 
 /**


### PR DESCRIPTION
- add `<meta name="color-scheme" content="dark light">`
  to hint browser canvas color from system preference
- move inline theme init `<script>` before `<style>` so
  `dark` class and `style.colorScheme` are set before
  styles are parsed
- remove `color-scheme` from inline `<style>` since
  meta tag and script now handle it
- update `applyTheme` in `theme/index.ts` to sync
  `style.colorScheme` on theme toggle
