### PR TITLE
🐞fix:(front) fix dark mode FOUC on load

### DIFF
--- a/front/src/_includes/BaseLayout.tsx
+++ b/front/src/_includes/BaseLayout.tsx
@@ -46,11 +46,11 @@ export default (
           }}
         >
         </script>
-        {/* FOUC prevention: hide content until CSS loads, set canvas bg per theme */}
+        {/* FOUC prevention: html bg paints the canvas, body hides content */}
         <style
           dangerouslySetInnerHTML={{
             __html:
-              "html{visibility:hidden;opacity:0;background-color:#fdf6e3}html.dark{background-color:#2d353b}",
+              "html{background-color:#fdf6e3}html.dark{background-color:#2d353b}body{visibility:hidden}",
           }}
         >
         </style>

--- a/front/src/assets/styles/base/document.css
+++ b/front/src/assets/styles/base/document.css
@@ -9,11 +9,10 @@
     font-size: 16px;
     background-color: var(--color-bg-primary);
     color: var(--color-fg-primary);
-    visibility: visible !important;
-    opacity: 1 !important;
   }
 
   body {
     font-size: var(--font-size-base);
+    visibility: visible !important;
   }
 }


### PR DESCRIPTION
- move `visibility:hidden` from `html` to `body` so
  canvas background stays visible with correct theme
- remove `opacity:0` from `html` which was making the
  dark background transparent and exposing the white
  browser canvas beneath
- move `visibility: visible !important` override from
  `html` to `body` in `document.css`
