### PR TITLE
🐞fix:(front) exclude theme init from Rocket Loader

### DIFF
--- a/front/src/_includes/BaseLayout.tsx
+++ b/front/src/_includes/BaseLayout.tsx
@@ -39,7 +39,9 @@ export default (
         {/* title */}
         <title>{title ? `${title} | ${site.name}` : site.name}</title>
         {/* critical theme init: must run BEFORE styles to set class and color-scheme */}
+        {/* data-cfasync=false excludes this from Cloudflare Rocket Loader */}
         <script
+          data-cfasync="false"
           dangerouslySetInnerHTML={{
             __html:
               `(function(){var d=document.documentElement;try{var t=localStorage.getItem("theme")}catch(e){var t=null}if(!t)t=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";if(t==="dark"){d.classList.add("dark");d.style.colorScheme="dark"}else{d.style.colorScheme="light"}})()`,


### PR DESCRIPTION
- add `data-cfasync="false"` to inline theme init
  script so Cloudflare Rocket Loader does not defer
  it, which was causing dark mode FOUC on production
