### PR TITLE
♻️refactor:(front) centralize CSS class names

### DIFF
--- a/front/src/_includes/BaseLayout.tsx
+++ b/front/src/_includes/BaseLayout.tsx
@@ -34,12 +34,11 @@ export default (
           content="#2d353b"
           media="(prefers-color-scheme: dark)"
         />
-        {/* hint browser to use system-preferred canvas color before any CSS */}
+        {/* canvas color hint */}
         <meta name="color-scheme" content="dark light" />
         {/* title */}
         <title>{title ? `${title} | ${site.name}` : site.name}</title>
-        {/* critical theme init: must run BEFORE styles to set class and color-scheme */}
-        {/* data-cfasync=false excludes this from Cloudflare Rocket Loader */}
+        {/* theme init: data-cfasync=false to bypass Cloudflare Rocket Loader */}
         <script
           data-cfasync="false"
           dangerouslySetInnerHTML={{
@@ -48,7 +47,7 @@ export default (
           }}
         >
         </script>
-        {/* FOUC prevention: html bg paints the canvas, body hides content */}
+        {/* hide body until main CSS loads */}
         <style
           dangerouslySetInnerHTML={{
             __html:

--- a/front/src/assets/scripts/core/constants.ts
+++ b/front/src/assets/scripts/core/constants.ts
@@ -7,38 +7,36 @@
  */
 export const CSS_CLASSES = {
   // terminal output states
-  /** Error state class */
   ERROR: "terminal-error",
-  /** Success state class */
   SUCCESS: "terminal-success",
-  /** Info state class */
   INFO: "terminal-info",
   // terminal structure
-  /** Link element class */
   LINK: "terminal-link",
-  /** Command text class */
   COMMAND: "terminal-command",
-  // terminal UI
-  /** Prompt line class */
+  // terminal prompt
   PROMPT: "terminal-prompt",
-  /** Username display class */
   USER: "terminal-user",
-  /** Hostname display class */
   HOST: "terminal-host",
-  /** Path display class */
   PATH: "terminal-path",
+  AT: "terminal-at",
+  COLON: "terminal-colon",
+  DOLLAR: "terminal-dollar",
   // terminal history
-  /** History item container class */
   HISTORY_ITEM: "terminal-history-item",
-  /** History command text class */
   HISTORY_COMMAND: "terminal-history-command",
-  /** History output text class */
   HISTORY_OUTPUT: "terminal-history-output",
-  // spotify terminal output
-  /** Spotify field key class */
+  // terminal UI
+  HINT: "terminal-hint",
+  ASCII_ART: "terminal-ascii-art",
+  STDIN_PROMPT: "terminal-stdin-prompt",
+  // terminal help
+  HELP_LIST: "terminal-help-list",
+  HELP_ITEM: "terminal-help-item",
+  HELP_DESC: "terminal-help-desc",
+  // spotify
   SPOTIFY_KEY: "spotify-key",
-  /** Spotify field value class */
   SPOTIFY_VALUE: "spotify-value",
+  SPOTIFY_ALBUM_IMAGE: "spotify-album-image",
 } as const;
 
 export type CssClass = (typeof CSS_CLASSES)[keyof typeof CSS_CLASSES];

--- a/front/src/assets/scripts/router/index.ts
+++ b/front/src/assets/scripts/router/index.ts
@@ -156,7 +156,11 @@ async function navigateTo(
     };
     // use View Transitions API if available
     if (document.startViewTransition) {
-      document.startViewTransition(doSwap);
+      document.documentElement.classList.add("spa-navigating");
+      const transition = document.startViewTransition(doSwap);
+      transition.finished.then(() => {
+        document.documentElement.classList.remove("spa-navigating");
+      });
     } else {
       doSwap();
     }

--- a/front/src/assets/scripts/terminal/commands/grep.ts
+++ b/front/src/assets/scripts/terminal/commands/grep.ts
@@ -479,7 +479,7 @@ export const grep: Command = {
         const historyEl = document.getElementById("terminal-history");
         if (historyEl && result) {
           const outputEl = document.createElement("div");
-          outputEl.className = "terminal-history-output";
+          outputEl.className = CSS_CLASSES.HISTORY_OUTPUT;
           outputEl.innerHTML = result;
           historyEl.appendChild(outputEl);
         }

--- a/front/src/assets/scripts/terminal/commands/help.ts
+++ b/front/src/assets/scripts/terminal/commands/help.ts
@@ -4,6 +4,7 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 
 export const help: Command = {
   name: "help",
@@ -19,12 +20,12 @@ export const help: Command = {
     );
     const commandList = filteredCommands
       .map((cmd) =>
-        `<div class="terminal-help-item">` +
-        `<span class="terminal-command">${cmd.name}</span>` +
-        `<span class="terminal-help-desc">${cmd.description}</span>` +
+        `<div class="${CSS_CLASSES.HELP_ITEM}">` +
+        `<span class="${CSS_CLASSES.COMMAND}">${cmd.name}</span>` +
+        `<span class="${CSS_CLASSES.HELP_DESC}">${cmd.description}</span>` +
         `</div>`
       )
       .join("");
-    return `<div class="terminal-success">Available commands:</div><div class="terminal-help-list">${commandList}</div>\n<div>Type a command and press Enter to execute.</div>`;
+    return `<div class="${CSS_CLASSES.SUCCESS}">Available commands:</div><div class="${CSS_CLASSES.HELP_LIST}">${commandList}</div>\n<div>Type a command and press Enter to execute.</div>`;
   },
 };

--- a/front/src/assets/scripts/terminal/commands/keybindings.ts
+++ b/front/src/assets/scripts/terminal/commands/keybindings.ts
@@ -4,6 +4,7 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 // core
 import { MAN_PAGES } from "../core/man-pages.ts";
 
@@ -20,7 +21,7 @@ export const keybindings: Command = {
         `<pre class="whitespace-pre-wrap text-sm">${manPage.options}</pre>`;
     }
     output +=
-      `<div class="mt-3 text-muted">Tip: Use <span class="terminal-command">man keybindings</span> for detailed manual page</div>`;
+      `<div class="mt-3 text-muted">Tip: Use <span class="${CSS_CLASSES.COMMAND}">man keybindings</span> for detailed manual page</div>`;
     return output;
   },
 };

--- a/front/src/assets/scripts/terminal/commands/spotify.ts
+++ b/front/src/assets/scripts/terminal/commands/spotify.ts
@@ -72,7 +72,7 @@ async function createSpotifyDisplay(
 
   // header line with user@spotify format (like fastfetch's user@host)
   lines.push(
-    `<a href="${spotifyProfileUrl}" target="_blank" rel="noopener noreferrer" class="terminal-link" style="font-weight: 600;">${getUsername()}@spotify</a>`,
+    `<a href="${spotifyProfileUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}" style="font-weight: 600;">${getUsername()}@spotify</a>`,
   );
   lines.push(
     `<span style="color: var(--color-fg-secondary);">-----------------</span>`,
@@ -92,13 +92,13 @@ async function createSpotifyDisplay(
   }
 
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.TRACK} Track</span>:  <a href="${track.trackUrl}" target="_blank" rel="noopener noreferrer" class="terminal-link">${track.trackName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.TRACK} Track</span>:  <a href="${track.trackUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.trackName}</a>`,
   );
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ALBUM} Album</span>:  <a href="${track.albumUrl}" target="_blank" rel="noopener noreferrer" class="terminal-link">${track.albumName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ALBUM} Album</span>:  <a href="${track.albumUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.albumName}</a>`,
   );
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ARTIST} Artist</span>: <a href="${track.artistUrl}" target="_blank" rel="noopener noreferrer" class="terminal-link">${track.artistName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ARTIST} Artist</span>: <a href="${track.artistUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.artistName}</a>`,
   );
   // calculate image size based on number of lines
   const { lineHeight, fontFamily, imageMargin } = SPOTIFY_DISPLAY_CONFIG;
@@ -107,7 +107,7 @@ async function createSpotifyDisplay(
   // use table layout for better alignment (neofetch-style)
   return `<pre style="font-family: '${fontFamily}', monospace; line-height: ${lineHeight}; margin: 0.5rem 0;"><span style="display: inline-block; vertical-align: top; margin-right: ${imageMargin};">${
     imageBase64
-      ? `<img src="${imageBase64}" alt="${track.albumName} artwork" class="spotify-album-image" style="width: ${imageSize}; height: ${imageSize}; object-fit: cover; border-radius: 4px; display: block; cursor: pointer;" data-album-name="${track.albumName}">`
+      ? `<img src="${imageBase64}" alt="${track.albumName} artwork" class="${CSS_CLASSES.SPOTIFY_ALBUM_IMAGE}" style="width: ${imageSize}; height: ${imageSize}; object-fit: cover; border-radius: 4px; display: block; cursor: pointer;" data-album-name="${track.albumName}">`
       : `<span style="display: block; width: ${imageSize}; height: ${imageSize}; background-color: var(--color-bg-elevated); border-radius: 4px; text-align: center; line-height: ${imageSize}; color: var(--color-fg-secondary); font-size: 3em;">${SPOTIFY_FIELD_ICONS.SPOTIFY}</span>`
   }</span><span style="display: inline-block; vertical-align: top;">${
     lines.join("\n")

--- a/front/src/assets/scripts/terminal/commands/welcome.ts
+++ b/front/src/assets/scripts/terminal/commands/welcome.ts
@@ -4,18 +4,19 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 
 export const welcome: Command = {
   name: "welcome",
   description: "Show welcome message",
   execute: () => {
-    return `<pre class="terminal-ascii-art">
+    return `<pre class="${CSS_CLASSES.ASCII_ART}">
    __  ______ _____  ____  ________  ____ _ ____  _________ _
   / / / / __ \`/ __ \\/ __ \\/ ___/ _ \\/ __ \`// __ \\/ ___/ __ \`/
  / /_/ / /_/ / / / / /_/ (__  )  __/ /_/ // /_/ / /  / /_/ /
  \\__, /\\__,_/_/ /_/\\____/____/\\___/\\__,_(_)____/_/   \\__, /
 /____/                                              /____/
 </pre>
-Type <span class="terminal-command">help</span> to see available commands.`;
+Type <span class="${CSS_CLASSES.COMMAND}">help</span> to see available commands.`;
   },
 };

--- a/front/src/assets/scripts/terminal/core/autocomplete.ts
+++ b/front/src/assets/scripts/terminal/core/autocomplete.ts
@@ -4,6 +4,7 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 
 /**
  * Handle autocomplete for the terminal input
@@ -29,7 +30,7 @@ export function handleAutocomplete(
   } else if (matches.length > 1) {
     // multiple matches - show hints
     hints.innerHTML = matches
-      .map((cmd) => `<span class="terminal-hint">${cmd.name}</span>`)
+      .map((cmd) => `<span class="${CSS_CLASSES.HINT}">${cmd.name}</span>`)
       .join("");
     hints.style.display = "flex";
   } else {

--- a/front/src/assets/scripts/terminal/core/executor.ts
+++ b/front/src/assets/scripts/terminal/core/executor.ts
@@ -5,6 +5,7 @@
 // types
 import type { Command } from "@/types/terminal.ts";
 // utils
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 import { addToHistory } from "./history.ts";
 import { escapeHtml, getPromptHtml, scrollToBottom } from "./utils.ts";
 
@@ -69,13 +70,14 @@ async function executePipeChain(
   }
   // create history item container
   const historyItem = document.createElement("div");
-  historyItem.className = "terminal-history-item";
+  historyItem.className = CSS_CLASSES.HISTORY_ITEM;
   // create command display element with prompt
   const commandEl = document.createElement("div");
-  commandEl.className = "terminal-history-command flex items-center gap-2";
+  commandEl.className =
+    `${CSS_CLASSES.HISTORY_COMMAND} flex items-center gap-2`;
   // build prompt span with styled components
   const promptSpan = document.createElement("span");
-  promptSpan.className = "terminal-prompt";
+  promptSpan.className = CSS_CLASSES.PROMPT;
   promptSpan.innerHTML = getPromptHtml();
   // create span to display the full piped command
   const commandSpan = document.createElement("span");
@@ -99,10 +101,11 @@ async function executePipeChain(
     // if command not found, show error and exit
     if (!command) {
       const outputEl = document.createElement("div");
-      outputEl.className = "terminal-history-output";
-      outputEl.innerHTML = `<span class="terminal-error">command not found: ${
-        escapeHtml(cmdName)
-      }</span>`;
+      outputEl.className = CSS_CLASSES.HISTORY_OUTPUT;
+      outputEl.innerHTML =
+        `<span class="${CSS_CLASSES.ERROR}">command not found: ${
+          escapeHtml(cmdName)
+        }</span>`;
       historyItem.appendChild(outputEl);
       return;
     }
@@ -115,7 +118,7 @@ async function executePipeChain(
         // last command in chain: display output to user
         if (output !== undefined && output !== null) {
           const outputEl = document.createElement("div");
-          outputEl.className = "terminal-history-output";
+          outputEl.className = CSS_CLASSES.HISTORY_OUTPUT;
           outputEl.innerHTML = output;
           historyItem.appendChild(outputEl);
         }
@@ -126,8 +129,8 @@ async function executePipeChain(
     } catch (error) {
       // handle command execution error
       const outputEl = document.createElement("div");
-      outputEl.className = "terminal-history-output";
-      outputEl.innerHTML = `<span class="terminal-error">error: ${
+      outputEl.className = CSS_CLASSES.HISTORY_OUTPUT;
+      outputEl.innerHTML = `<span class="${CSS_CLASSES.ERROR}">error: ${
         escapeHtml(error instanceof Error ? error.message : String(error))
       }</span>`;
       historyItem.appendChild(outputEl);

--- a/front/src/assets/scripts/terminal/core/history.ts
+++ b/front/src/assets/scripts/terminal/core/history.ts
@@ -5,6 +5,7 @@
 // types
 import type { Command } from "@/types/terminal.ts";
 // config
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 import { RESTRICTED_UNIX_COMMANDS } from "./config.ts";
 // utils
 import { escapeHtml, getPromptHtml } from "./utils.ts";
@@ -159,13 +160,14 @@ export async function addToHistory(
     return;
   }
   const historyItem = document.createElement("div");
-  historyItem.className = "terminal-history-item";
+  historyItem.className = CSS_CLASSES.HISTORY_ITEM;
   // command line - create and add immediately
   const commandEl = document.createElement("div");
-  commandEl.className = "terminal-history-command flex items-center gap-2";
+  commandEl.className =
+    `${CSS_CLASSES.HISTORY_COMMAND} flex items-center gap-2`;
   // build prompt separately to avoid innerHTML for the command text
   const promptSpan = document.createElement("span");
-  promptSpan.className = "terminal-prompt";
+  promptSpan.className = CSS_CLASSES.PROMPT;
   promptSpan.innerHTML = getPromptHtml();
   // use textContent for the command to avoid innerHTML re-parsing
   const commandSpan = document.createElement("span");
@@ -177,7 +179,7 @@ export async function addToHistory(
   historyEl.appendChild(historyItem);
   // output - process and add after command execution
   const outputEl = document.createElement("div");
-  outputEl.className = "terminal-history-output";
+  outputEl.className = CSS_CLASSES.HISTORY_OUTPUT;
   if (command) {
     const result = command.execute(args, allCommands);
     // handle both sync and async commands
@@ -193,13 +195,15 @@ export async function addToHistory(
       cmdName as typeof RESTRICTED_UNIX_COMMANDS[number],
     );
     if (isRestrictedCommand) {
-      outputEl.innerHTML = `<span class="terminal-error">permission denied: ${
-        escapeHtml(cmdName)
-      }</span>`;
+      outputEl.innerHTML =
+        `<span class="${CSS_CLASSES.ERROR}">permission denied: ${
+          escapeHtml(cmdName)
+        }</span>`;
     } else {
-      outputEl.innerHTML = `<span class="terminal-error">command not found: ${
-        escapeHtml(commandLine)
-      }</span>`;
+      outputEl.innerHTML =
+        `<span class="${CSS_CLASSES.ERROR}">command not found: ${
+          escapeHtml(commandLine)
+        }</span>`;
     }
     historyItem.appendChild(outputEl);
   }

--- a/front/src/assets/scripts/terminal/core/stdin.ts
+++ b/front/src/assets/scripts/terminal/core/stdin.ts
@@ -2,6 +2,7 @@
  * Terminal Stdin Mode Management
  */
 
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 // utils
 import { scrollToBottom } from "./utils.ts";
 
@@ -76,9 +77,9 @@ export function addStdinLine(line: string): void {
   }
   // display the input line with a stdin prompt
   const lineEl = document.createElement("div");
-  lineEl.className = "terminal-history-item";
+  lineEl.className = CSS_CLASSES.HISTORY_ITEM;
   const promptSpan = document.createElement("span");
-  promptSpan.className = "terminal-stdin-prompt";
+  promptSpan.className = CSS_CLASSES.STDIN_PROMPT;
   promptSpan.textContent = "> ";
   const textSpan = document.createElement("span");
   textSpan.textContent = line;

--- a/front/src/assets/scripts/terminal/core/utils.ts
+++ b/front/src/assets/scripts/terminal/core/utils.ts
@@ -144,7 +144,7 @@ export function escapeHtml(text: string): string {
  */
 export function getPromptHtml(): string {
   const hostname = getSiteName();
-  return `<span class="terminal-user">you</span> <span class="terminal-at">@</span> <span class="terminal-host">${hostname}</span> <span class="terminal-colon">:</span> <span class="terminal-path">~</span> <span class="terminal-dollar">$</span> `;
+  return `<span class="${CSS_CLASSES.USER}">you</span> <span class="${CSS_CLASSES.AT}">@</span> <span class="${CSS_CLASSES.HOST}">${hostname}</span> <span class="${CSS_CLASSES.COLON}">:</span> <span class="${CSS_CLASSES.PATH}">~</span> <span class="${CSS_CLASSES.DOLLAR}">$</span> `;
 }
 
 /** Active countdown interval ID for cleanup */

--- a/front/src/assets/scripts/terminal/index.ts
+++ b/front/src/assets/scripts/terminal/index.ts
@@ -4,6 +4,7 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 // commands
 import * as commands from "./commands/index.ts";
 // core
@@ -126,7 +127,7 @@ function initTerminal(): void {
     container.addEventListener("click", (e) => {
       // handle spotify album image clicks
       const target = e.target as HTMLElement;
-      if (target.classList.contains("spotify-album-image")) {
+      if (target.classList.contains(CSS_CLASSES.SPOTIFY_ALBUM_IMAGE)) {
         const img = target as HTMLImageElement;
         const albumName = img.dataset.albumName || img.alt;
         openImageModal(
@@ -168,12 +169,12 @@ function initTerminal(): void {
       const historyEl = document.getElementById("terminal-history");
       if (historyEl) {
         const historyItem = document.createElement("div");
-        historyItem.className = "terminal-history-item";
+        historyItem.className = CSS_CLASSES.HISTORY_ITEM;
         const commandEl = document.createElement("div");
         commandEl.className =
-          "terminal-history-command flex items-center gap-2";
+          `${CSS_CLASSES.HISTORY_COMMAND} flex items-center gap-2`;
         const promptSpan = document.createElement("span");
-        promptSpan.className = "terminal-prompt";
+        promptSpan.className = CSS_CLASSES.PROMPT;
         promptSpan.innerHTML = getPromptHtml();
         commandEl.appendChild(promptSpan);
         historyItem.appendChild(commandEl);

--- a/front/src/assets/styles/components/router.css
+++ b/front/src/assets/styles/components/router.css
@@ -2,13 +2,19 @@
  * SPA Router View Transitions
  * Elements with view-transition-name become independent layers during
  * transitions, preserving their stacking order (z-index).
+ * Names are scoped to .spa-navigating so theme toggle uses a single
+ * root layer for uniform cross-fade.
  */
 
-#main-content {
+.spa-navigating #main-content {
   view-transition-name: main-content;
 }
 
-#spotify-status-container {
+.spa-navigating header {
+  view-transition-name: header;
+}
+
+.spa-navigating #spotify-status-container {
   view-transition-name: spotify-widget;
 }
 


### PR DESCRIPTION
- replace hardcoded CSS class strings with `CSS_CLASSES`
  constants across terminal scripts
- add `AT`, `COLON`, `DOLLAR`, `HINT`, `ASCII_ART`,
  `STDIN_PROMPT`, `HELP_LIST`, `HELP_ITEM`, `HELP_DESC`,
  `SPOTIFY_ALBUM_IMAGE` to `CSS_CLASSES`
- remove per-field JSDoc comments from `CSS_CLASSES`
- scope `view-transition-name` to `.spa-navigating` for
  uniform theme toggle cross-fade
- add `header` `view-transition-name` to preserve sticky
  header during view transitions
- simplify comments in `BaseLayout.tsx`
