### PR TITLE
✨feat:(front) sanitize terminal HTML output

### DIFF
--- a/front/src/assets/scripts/terminal/commands/cd.ts
+++ b/front/src/assets/scripts/terminal/commands/cd.ts
@@ -8,7 +8,11 @@ import type { Command } from "@/types/terminal.ts";
 import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 import { ROUTING_CONFIG } from "@/assets/scripts/core/config.ts";
 // core
-import { getAllPages, redirectWithCountdown } from "../core/utils.ts";
+import {
+  escapeHtml,
+  getAllPages,
+  redirectWithCountdown,
+} from "../core/utils.ts";
 
 /**
  * Map of error messages
@@ -61,7 +65,9 @@ export const cd: Command = {
       });
       // if path doesn't exist, return error message
       if (!pathExists) {
-        return `<span class="${CSS_CLASSES.ERROR}">cd: ${normalizedArg}: ${MESSAGES.NO_SUCH_DIR}</span>`;
+        return `<span class="${CSS_CLASSES.ERROR}">cd: ${
+          escapeHtml(normalizedArg)
+        }: ${MESSAGES.NO_SUCH_DIR}</span>`;
       }
       // allow validated path - construct URL from the path argument
       const normalizedPath = normalizedInputPath;

--- a/front/src/assets/scripts/terminal/commands/echo.ts
+++ b/front/src/assets/scripts/terminal/commands/echo.ts
@@ -4,6 +4,8 @@
 
 // types
 import type { Command } from "@/types/terminal.ts";
+// utils
+import { escapeHtml } from "../core/utils.ts";
 
 /**
  * Echo command options
@@ -117,9 +119,9 @@ export const echo: Command = {
       text = interpretEscapes(text);
     }
     if (options.noNewline) {
-      return text;
+      return escapeHtml(text);
     } else {
-      return text || "\n";
+      return text ? escapeHtml(text) : "\n";
     }
   },
 };

--- a/front/src/assets/scripts/terminal/commands/man.ts
+++ b/front/src/assets/scripts/terminal/commands/man.ts
@@ -9,6 +9,7 @@ import type { Command } from "@/types/terminal.ts";
 import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
 import { MAN_PAGES } from "../core/man-pages.ts";
 import { MAN_SECTIONS } from "../core/config.ts";
+import { escapeHtml } from "../core/utils.ts";
 
 /**
  * Man error messages
@@ -45,7 +46,9 @@ function formatNoArgsMessage(): string {
  * @returns Error message HTML
  */
 function formatNoEntryMessage(commandName: string): string {
-  return `<span class="${CSS_CLASSES.ERROR}">${MESSAGES.NO_ENTRY} ${commandName}</span>`;
+  return `<span class="${CSS_CLASSES.ERROR}">${MESSAGES.NO_ENTRY} ${
+    escapeHtml(commandName)
+  }</span>`;
 }
 
 /**
@@ -153,7 +156,9 @@ function searchByKeyword(keyword: string, allCommands?: Command[]): string {
   });
 
   if (matches.length === 0) {
-    return `<span class="${CSS_CLASSES.ERROR}">Nothing appropriate for "${keyword}"</span>`;
+    return `<span class="${CSS_CLASSES.ERROR}">Nothing appropriate for "${
+      escapeHtml(keyword)
+    }"</span>`;
   }
 
   const output = matches

--- a/front/src/assets/scripts/terminal/commands/spotify.ts
+++ b/front/src/assets/scripts/terminal/commands/spotify.ts
@@ -17,6 +17,7 @@ import {
   SPOTIFY_DISPLAY_CONFIG,
   SPOTIFY_ELEMENT_IDS,
 } from "@/assets/scripts/core/config.ts";
+import { escapeHtml } from "../core/utils.ts";
 
 /**
  * Spotify command messages
@@ -87,18 +88,26 @@ async function createSpotifyDisplay(
 
   if (track.playedAt) {
     lines.push(
-      `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.PLAYED} Played</span>: <span class="${CSS_CLASSES.SPOTIFY_VALUE}">${track.playedAt}</span>`,
+      `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.PLAYED} Played</span>: <span class="${CSS_CLASSES.SPOTIFY_VALUE}">${
+        escapeHtml(track.playedAt)
+      }</span>`,
     );
   }
 
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.TRACK} Track</span>:  <a href="${track.trackUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.trackName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.TRACK} Track</span>:  <a href="${track.trackUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${
+      escapeHtml(track.trackName)
+    }</a>`,
   );
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ALBUM} Album</span>:  <a href="${track.albumUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.albumName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ALBUM} Album</span>:  <a href="${track.albumUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${
+      escapeHtml(track.albumName)
+    }</a>`,
   );
   lines.push(
-    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ARTIST} Artist</span>: <a href="${track.artistUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${track.artistName}</a>`,
+    `<span class="${CSS_CLASSES.SPOTIFY_KEY}">${SPOTIFY_FIELD_ICONS.ARTIST} Artist</span>: <a href="${track.artistUrl}" target="_blank" rel="noopener noreferrer" class="${CSS_CLASSES.LINK}">${
+      escapeHtml(track.artistName)
+    }</a>`,
   );
   // calculate image size based on number of lines
   const { lineHeight, fontFamily, imageMargin } = SPOTIFY_DISPLAY_CONFIG;
@@ -107,7 +116,11 @@ async function createSpotifyDisplay(
   // use table layout for better alignment (neofetch-style)
   return `<pre style="font-family: '${fontFamily}', monospace; line-height: ${lineHeight}; margin: 0.5rem 0;"><span style="display: inline-block; vertical-align: top; margin-right: ${imageMargin};">${
     imageBase64
-      ? `<img src="${imageBase64}" alt="${track.albumName} artwork" class="${CSS_CLASSES.SPOTIFY_ALBUM_IMAGE}" style="width: ${imageSize}; height: ${imageSize}; object-fit: cover; border-radius: 4px; display: block; cursor: pointer;" data-album-name="${track.albumName}">`
+      ? `<img src="${imageBase64}" alt="${
+        escapeHtml(track.albumName)
+      } artwork" class="${CSS_CLASSES.SPOTIFY_ALBUM_IMAGE}" style="width: ${imageSize}; height: ${imageSize}; object-fit: cover; border-radius: 4px; display: block; cursor: pointer;" data-album-name="${
+        escapeHtml(track.albumName)
+      }">`
       : `<span style="display: block; width: ${imageSize}; height: ${imageSize}; background-color: var(--color-bg-elevated); border-radius: 4px; text-align: center; line-height: ${imageSize}; color: var(--color-fg-secondary); font-size: 3em;">${SPOTIFY_FIELD_ICONS.SPOTIFY}</span>`
   }</span><span style="display: inline-block; vertical-align: top;">${
     lines.join("\n")

--- a/front/src/assets/scripts/terminal/core/formatter.ts
+++ b/front/src/assets/scripts/terminal/core/formatter.ts
@@ -4,6 +4,7 @@
 
 // utils
 import { CSS_CLASSES } from "@/assets/scripts/core/constants.ts";
+import { escapeHtml } from "./utils.ts";
 
 /**
  * Highlight a match within text
@@ -19,9 +20,11 @@ export function highlightMatch(
   matchLength: number,
   cssClass: string = CSS_CLASSES.ERROR,
 ): string {
-  if (matchIndex < 0 || matchLength <= 0) return text;
+  if (matchIndex < 0 || matchLength <= 0) return escapeHtml(text);
   const before = text.substring(0, matchIndex);
   const match = text.substring(matchIndex, matchIndex + matchLength);
   const after = text.substring(matchIndex + matchLength);
-  return `${before}<span class="${cssClass}">${match}</span>${after}`;
+  return `${escapeHtml(before)}<span class="${cssClass}">${
+    escapeHtml(match)
+  }</span>${escapeHtml(after)}`;
 }

--- a/front/src/assets/scripts/terminal/core/utils.ts
+++ b/front/src/assets/scripts/terminal/core/utils.ts
@@ -179,9 +179,9 @@ export function redirectWithCountdown(
   }
   let countdown = TIMING_CONFIG.redirectCountdownSeconds;
   const formatMsg = (n: number) =>
-    `<span class="${CSS_CLASSES.SUCCESS}">Redirecting to ${pageName} page in ${n} second${
-      n !== 1 ? "s" : ""
-    }...</span>`;
+    `<span class="${CSS_CLASSES.SUCCESS}">Redirecting to ${
+      escapeHtml(pageName)
+    } page in ${n} second${n !== 1 ? "s" : ""}...</span>`;
   countdownIntervalId = setInterval(() => {
     countdown--;
     if (!document.getElementById("terminal-form")) {


### PR DESCRIPTION
apply `escapeHtml()` to user input in `echo.ts` to prevent XSS via `innerHTML` rendering

- escape spotify API data (`trackName`, `albumName`, `artistName`, `playedAt`) and HTML attributes in `spotify.ts`
- escape `normalizedArg` in `cd.ts` error message
- escape `commandName` and `keyword` in `man.ts` error messages
- escape `pageName` in `redirectWithCountdown` in `utils.ts`
- escape text segments in `highlightMatch` in `formatter.ts` to prevent HTML interpretation

closes #254