### PR TITLE
✨feat(front): adopt clean URLs without .html

### DIFF
--- a/front/_config.ts
+++ b/front/_config.ts
@@ -58,6 +58,13 @@ site.process([".html"], (pages) => {
       link.setAttribute("target", "_blank");
       link.setAttribute("rel", "noopener noreferrer");
     });
+    // strip trailing slashes from internal links
+    page.document.querySelectorAll('a[href^="/"]').forEach((link) => {
+      const href = link.getAttribute("href");
+      if (href && href !== "/" && href.endsWith("/")) {
+        link.setAttribute("href", href.replace(/\/+$/, ""));
+      }
+    });
   }
 });
 // plugin config

--- a/front/src/_components/layouts/Header.tsx
+++ b/front/src/_components/layouts/Header.tsx
@@ -39,15 +39,15 @@ export default function Header(
           {/* navigation links */}
           <div className="hidden items-baseline gap-4 py-5 md:flex">
             {/* about page */}
-            <comp.ui.NavLink href="/about.html" iconName="lucide/info">
+            <comp.ui.NavLink href="/about" iconName="lucide/info">
               about
             </comp.ui.NavLink>
             {/* blog page */}
-            <comp.ui.NavLink href="/blog.html" iconName="lucide/notebook-pen">
+            <comp.ui.NavLink href="/blog" iconName="lucide/notebook-pen">
               blog
             </comp.ui.NavLink>
             {/* links page */}
-            <comp.ui.NavLink href="/links.html" iconName="lucide/link">
+            <comp.ui.NavLink href="/links" iconName="lucide/link">
               links
             </comp.ui.NavLink>
             {/* RSS */}

--- a/front/src/_components/layouts/MobileMenu.tsx
+++ b/front/src/_components/layouts/MobileMenu.tsx
@@ -16,7 +16,7 @@ export default function MobileMenu({ comp }: Lume.Data) {
         <div className="px-6 pb-4 mobile-menu-links">
           {/* about page */}
           <comp.ui.NavLink
-            href="/about.html"
+            href="/about"
             className="nav-link"
             iconName="lucide/info"
           >
@@ -24,7 +24,7 @@ export default function MobileMenu({ comp }: Lume.Data) {
           </comp.ui.NavLink>
           {/* blog page */}
           <comp.ui.NavLink
-            href="/blog.html"
+            href="/blog"
             className="nav-link"
             iconName="lucide/notebook-pen"
           >
@@ -32,7 +32,7 @@ export default function MobileMenu({ comp }: Lume.Data) {
           </comp.ui.NavLink>
           {/* links page */}
           <comp.ui.NavLink
-            href="/links.html"
+            href="/links"
             className="nav-link"
             iconName="lucide/link"
           >

--- a/front/src/_components/ui/Tag.tsx
+++ b/front/src/_components/ui/Tag.tsx
@@ -20,7 +20,7 @@ export default function Tag({
   baseUrl?: string;
   className?: string;
 }) {
-  const href = `${baseUrl}${tag}.html`;
+  const href = `${baseUrl}${tag}`;
 
   return (
     // tag

--- a/front/src/_data.ts
+++ b/front/src/_data.ts
@@ -68,8 +68,13 @@ export const metas = {
  * @returns URL string
  */
 export function url(page: Lume.Page) {
-  if (page.src.path === "index") {
+  const path = page.src.path.replace(/^\//, "");
+  if (path === "index") {
     return "/";
   }
-  return page.src.path + ".html";
+  // 404 page must be output as /404.html for static hosting
+  if (path === "404") {
+    return "/404.html";
+  }
+  return page.src.path + "/";
 }

--- a/front/src/assets/scripts/core/config.ts
+++ b/front/src/assets/scripts/core/config.ts
@@ -87,11 +87,11 @@ export const ROUTING_CONFIG = {
   /** Page paths */
   pages: {
     /** About page */
-    about: "/about.html",
+    about: "/about",
     /** Blog page */
-    blog: "/blog.html",
+    blog: "/blog",
     /** Links page */
-    links: "/links.html",
+    links: "/links",
     /** Home page */
     home: "/",
   },

--- a/front/src/assets/scripts/terminal/commands/cd.ts
+++ b/front/src/assets/scripts/terminal/commands/cd.ts
@@ -69,14 +69,7 @@ export const cd: Command = {
           escapeHtml(normalizedArg)
         }: ${MESSAGES.NO_SUCH_DIR}</span>`;
       }
-      // allow validated path - construct URL from the path argument
-      const normalizedPath = normalizedInputPath;
-      // if path doesn't have .html extension, add it
-      if (!normalizedPath.endsWith(".html") && !normalizedPath.endsWith("/")) {
-        targetUrl = `${normalizedPath}.html`;
-      } else {
-        targetUrl = normalizedPath;
-      }
+      targetUrl = normalizedInputPath;
     } else {
       // empty path means home
       targetUrl = "/";

--- a/front/src/assets/scripts/terminal/commands/grep.ts
+++ b/front/src/assets/scripts/terminal/commands/grep.ts
@@ -415,7 +415,7 @@ async function searchInPages(
 
   for (const page of targetPages) {
     try {
-      const fetchPath = page.path === "/" ? "/" : page.path + ".html";
+      const fetchPath = page.path;
       const response = await fetch(fetchPath);
       if (!response.ok) continue;
 

--- a/front/src/assets/scripts/terminal/commands/pwd.ts
+++ b/front/src/assets/scripts/terminal/commands/pwd.ts
@@ -14,10 +14,10 @@ export const pwd: Command = {
   name: "pwd",
   description: "Print working directory",
   execute: () => {
-    // get page path, remove leading slash and .html extension
+    // get page path, remove leading slash and trailing slash
     const page = globalThis.location.pathname
       .replace(/^\//, "") // remove leading slash
-      .replace(/\.html$/, ""); // remove .html extension
+      .replace(/\/+$/, ""); // remove trailing slash
 
     // construct Unix-style path: /home/you or /home/you/page
     if (!page) {

--- a/front/src/assets/scripts/terminal/core/utils.ts
+++ b/front/src/assets/scripts/terminal/core/utils.ts
@@ -80,16 +80,16 @@ export async function getAllPages(): Promise<PageInfo[]> {
       if (!path.startsWith("/")) {
         path = "/" + path;
       }
-      // remove .html extension for display
-      const pathWithoutExt = path.replace(/\.html$/, "");
+      // remove trailing slash for display
+      const pathWithoutSlash = path.replace(/\/+$/, "") || "/";
       // extract name from path
-      const pathParts = pathWithoutExt.split("/").filter((p) => p);
+      const pathParts = pathWithoutSlash.split("/").filter((p) => p);
       const name = pathParts[pathParts.length - 1] || "index";
-      // use path without .html as key
-      if (!pagesMap.has(pathWithoutExt)) {
-        pagesMap.set(pathWithoutExt, {
+      // use path without trailing slash as key
+      if (!pagesMap.has(pathWithoutSlash)) {
+        pagesMap.set(pathWithoutSlash, {
           name: name,
-          path: pathWithoutExt,
+          path: pathWithoutSlash,
         });
       }
     });

--- a/front/src/blog.page.tsx
+++ b/front/src/blog.page.tsx
@@ -25,7 +25,7 @@ export default function* (
   const blogPosts = posts
     .filter((page) => {
       return page?.url?.toString().startsWith("/blog/") &&
-        page?.url !== "/blog.html" &&
+        page?.url !== "/blog/" &&
         !!page.title &&
         !!page.date;
     })
@@ -34,7 +34,7 @@ export default function* (
     }) as unknown as BlogPost[];
   // pagination options
   const options = {
-    url: (n: number) => n === 1 ? `/blog.html` : `/blog/page/${n}.html`,
+    url: (n: number) => n === 1 ? `/blog/` : `/blog/page/${n}/`,
     size: 5,
   };
   // yield paginated blog pages

--- a/front/src/blog/tag.page.tsx
+++ b/front/src/blog/tag.page.tsx
@@ -25,7 +25,7 @@ export default function* (
   const blogPosts = posts
     .filter((page) => {
       return page?.url?.toString().startsWith("/blog/") &&
-        page?.url !== "/blog.html" &&
+        page?.url !== "/blog/" &&
         !!page.title &&
         !!page.date;
     })
@@ -47,7 +47,7 @@ export default function* (
     // pagination options
     const options = {
       url: (n: number) =>
-        n === 1 ? `/blog/tag/${tag}.html` : `/blog/tag/${tag}/page/${n}.html`,
+        n === 1 ? `/blog/tag/${tag}/` : `/blog/tag/${tag}/page/${n}/`,
       size: 5,
     };
     // yield paginated tag pages


### PR DESCRIPTION
- remove `.html` extensions from all internal navigation links
- update `url()` helper in `_data.ts` to emit trailing-slash paths
- add trailing-slash stripping processor in `_config.ts`
- add `stripTrailingSlash` utility to SPA router for path normalization
- update `shouldIntercept` and `navigateTo` to compare normalized paths
- simplify `cd` command by removing `.html` extension logic
- update `pwd` and `grep` commands to handle slash-based paths
- update `getAllPages` utility to key pages by slash-stripped path
- update blog and tag pagination URLs to use trailing slashes
- preserve `/404.html` output for static hosting compatibility

closes #260