### PR TITLE
✨feat(front): improve spotify modal caption

### DIFF
--- a/front/src/assets/scripts/integrations/spotify/modal.ts
+++ b/front/src/assets/scripts/integrations/spotify/modal.ts
@@ -5,6 +5,7 @@
 // utils
 import { getElement } from "@/assets/scripts/core/dom.ts";
 import { openImageModal } from "../../modal/modal-functions.ts";
+import { SPOTIFY_FIELD_ICONS } from "@/assets/scripts/core/constants.ts";
 import { fetchLyrics } from "../lrclib/lyrics.ts";
 import { startLyrics, stopLyrics } from "../../modal/lyrics-renderer.ts";
 
@@ -38,11 +39,39 @@ export function initImageModal(): void {
   }
   // add click handler to open modal with album artwork
   albumImage.addEventListener("click", async () => {
-    openImageModal(
-      albumImage.src,
-      albumImage.alt,
-      albumLink.textContent ?? "",
-    );
+    const albumName = albumLink.textContent ?? "";
+    openImageModal(albumImage.src, albumImage.alt);
+    // build icon-styled caption (track, album, artist) matching widget layout
+    const captionEl = getElement("modal-image-caption", HTMLElement);
+    if (captionEl) {
+      captionEl.replaceChildren();
+      if (currentTrack && currentArtist) {
+        // single row with all track info
+        const row = document.createElement("div");
+        row.className = "flex items-center gap-4 flex-wrap justify-center";
+        const items: { icon: string; text: string }[] = [
+          { icon: SPOTIFY_FIELD_ICONS.TRACK, text: currentTrack },
+          { icon: SPOTIFY_FIELD_ICONS.ALBUM, text: albumName },
+          { icon: SPOTIFY_FIELD_ICONS.ARTIST, text: currentArtist },
+        ];
+        for (const { icon, text } of items) {
+          const item = document.createElement("span");
+          item.className = "inline-flex items-center gap-1";
+          // icon is a trusted SVG constant from SPOTIFY_FIELD_ICONS, not user input
+          const iconSpan = document.createElement("span");
+          iconSpan.className = "flex items-center";
+          iconSpan.innerHTML = icon;
+          const textSpan = document.createElement("span");
+          textSpan.textContent = text;
+          item.appendChild(iconSpan);
+          item.appendChild(textSpan);
+          row.appendChild(item);
+        }
+        captionEl.appendChild(row);
+      } else {
+        captionEl.textContent = albumName;
+      }
+    }
     // fetch and render lyrics
     if (currentArtist && currentTrack) {
       const lyricsData = await fetchLyrics(currentArtist, currentTrack);


### PR DESCRIPTION
- replace plain text caption with icon-styled
  track info (track, album, artist) using
  `SPOTIFY_FIELD_ICONS` constants
- build caption dynamically in `modal.ts` instead
  of passing caption string to `openImageModal`
- fall back to album name when track info is not
  available

closes #269