### PR TITLE
✨feat(front): add track link to spotify modal

### DIFF
--- a/front/src/assets/scripts/integrations/spotify/modal.ts
+++ b/front/src/assets/scripts/integrations/spotify/modal.ts
@@ -5,25 +5,32 @@
 // utils
 import { getElement } from "@/assets/scripts/core/dom.ts";
 import { openImageModal } from "../../modal/modal-functions.ts";
-import { SPOTIFY_FIELD_ICONS } from "@/assets/scripts/core/constants.ts";
+import {
+  CSS_CLASSES,
+  SPOTIFY_FIELD_ICONS,
+} from "@/assets/scripts/core/constants.ts";
 import { fetchLyrics } from "../lrclib/lyrics.ts";
 import { startLyrics, stopLyrics } from "../../modal/lyrics-renderer.ts";
 
-/** Current track info for lyrics fetching */
+/** Current track info for modal display */
 let currentArtist = "";
 let currentTrack = "";
+let currentTrackUrl = "";
 
 /**
- * Update current track info for lyrics
+ * Update current track info for modal display
  * @param artistName - Current artist name
  * @param trackName - Current track name
+ * @param trackUrl - Current track URL
  */
 export function updateCurrentTrack(
   artistName: string,
   trackName: string,
+  trackUrl: string,
 ): void {
   currentArtist = artistName;
   currentTrack = trackName;
+  currentTrackUrl = trackUrl;
 }
 
 /**
@@ -31,7 +38,10 @@ export function updateCurrentTrack(
  */
 export function initImageModal(): void {
   // get album image element
-  const albumImage = getElement("spotify-album-image", HTMLImageElement);
+  const albumImage = getElement(
+    CSS_CLASSES.SPOTIFY_ALBUM_IMAGE,
+    HTMLImageElement,
+  );
   // exit early if element not found
   if (!albumImage) {
     return;
@@ -39,22 +49,40 @@ export function initImageModal(): void {
   // add click handler to open modal with album artwork
   albumImage.addEventListener("click", async () => {
     openImageModal(albumImage.src, albumImage.alt);
-    // set track name with icon as caption
+    // apply Spotify styles and track link to modal image
+    const modalImage = getElement("modal-image", HTMLImageElement);
+    if (modalImage) {
+      modalImage.classList.add(
+        "cursor-pointer",
+        CSS_CLASSES.SPOTIFY_ALBUM_IMAGE,
+      );
+      if (currentTrackUrl) {
+        modalImage.onclick = () => {
+          globalThis.open(currentTrackUrl, "_blank", "noopener,noreferrer");
+        };
+      }
+    }
+    // set track name with icon as caption link
     const captionEl = getElement("modal-image-caption", HTMLElement);
     if (captionEl) {
       captionEl.replaceChildren();
       if (currentTrack) {
-        const item = document.createElement("span");
-        item.className = "inline-flex items-center gap-1";
-        // icon is a trusted SVG constant from SPOTIFY_FIELD_ICONS, not user input
-        const iconSpan = document.createElement("span");
-        iconSpan.className = "flex items-center";
-        iconSpan.innerHTML = SPOTIFY_FIELD_ICONS.TRACK;
+        const link = document.createElement("a");
+        link.href = currentTrackUrl;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
+        link.className = "inline-flex items-center gap-2 link-text";
+        // SPOTIFY_FIELD_ICONS.TRACK is a trusted SVG constant, not user input
+        const iconContainer = document.createElement("span");
+        iconContainer.className = "flex items-center";
+        const iconTemplate = document.createElement("template");
+        iconTemplate.innerHTML = SPOTIFY_FIELD_ICONS.TRACK;
+        iconContainer.appendChild(iconTemplate.content);
         const textSpan = document.createElement("span");
         textSpan.textContent = currentTrack;
-        item.appendChild(iconSpan);
-        item.appendChild(textSpan);
-        captionEl.appendChild(item);
+        link.appendChild(iconContainer);
+        link.appendChild(textSpan);
+        captionEl.appendChild(link);
       }
     }
     // fetch and render lyrics
@@ -73,6 +101,15 @@ export function initImageModal(): void {
   if (imageModal) {
     imageModal.addEventListener("close", () => {
       stopLyrics();
+      // remove Spotify-specific styles and handler from modal image
+      const modalImage = getElement("modal-image", HTMLImageElement);
+      if (modalImage) {
+        modalImage.classList.remove(
+          "cursor-pointer",
+          CSS_CLASSES.SPOTIFY_ALBUM_IMAGE,
+        );
+        modalImage.onclick = null;
+      }
     });
   }
 }

--- a/front/src/assets/scripts/integrations/spotify/ui.ts
+++ b/front/src/assets/scripts/integrations/spotify/ui.ts
@@ -384,7 +384,7 @@ export function updateUI(isNowPlaying: boolean, track: Track): void {
   // store current track for future comparison
   previousTrack = { ...track };
   // update track info for lyrics fetching
-  updateCurrentTrack(track.artistName, track.trackName);
+  updateCurrentTrack(track.artistName, track.trackName, track.trackUrl);
   previousIsNowPlaying = isNowPlaying;
   // skip animation if content unchanged
   if (!contentChanged) {


### PR DESCRIPTION
- add `currentTrackUrl` to track state and
  `updateCurrentTrack()` parameter
- link modal image click to spotify track url via
  `globalThis.open()`
- convert caption from `<span>` to `<a>` linking to
  track url with `link-text` style
- use `<template>` for safe SVG icon insertion
- dynamically apply/remove `spotify-album-image` and
  `cursor-pointer` on modal open/close to avoid
  affecting blog image modal
- use `CSS_CLASSES.SPOTIFY_ALBUM_IMAGE` constant

closes #275